### PR TITLE
"coin age" => "coinage"

### DIFF
--- a/minting.html
+++ b/minting.html
@@ -19,7 +19,7 @@
 		
         <h3> What is minting? </h3>
 		
-		<p>All coins in the Peercoin network collect coin age. Your stake is calculated from this coinage, measured by last transaction, and multiplied with the amount of coin (time * coins). 
+		<p>All coins in the Peercoin network collect coinage. Your stake is calculated from this coinage, measured by last transaction, and multiplied with the amount of coin (time * coins). 
 		Transferred coins lose their age and start a new "life" as fresh coins. When you keep coins for 30 days, they are old enough to start the minting process. 
 		From that moment on the software tests the 'search space' given by the coinage, the limited options are tested if they "solve the puzzle" like in Bitcoin mining. You can simply this by comparing it with a raffle. But it is a raffle that lets you keep the tickets every time you do not win a round. 
 		And with it the chance of producing a valid solution of the next puzzle increases. More coins equals more raffle tickets. So 100 coins at an age of 30 days are twice as likely to solve the "puzzle" as 50 coins with 30 age days. The maximum age a coin


### PR DESCRIPTION
The three other uses of this phrase in the file are "coinage", so I assume this is supposed to be that as well?
