### PR TITLE
Update proofofstake.php

### DIFF
--- a/proofofstake.php
+++ b/proofofstake.php
@@ -17,7 +17,7 @@
 					    Peercoin uses a hybrid proof-of-work/proof-of-stake system. Instead of being dependent on hashing power available, proof-of-stake blocks are distributed according to possession of the coins. For example, an individual possessing 1% of all Peercoins currently in existence would be able to mint 1% of the proof-of-stake blocks. Notice that the term "mint" is used in generation of proof-of-stake blocks. The term "mine" refers specifically to the generation of proof-of-work blocks. Minting can be performed by running a full node of the Peercoin client and does not require many resources. More information can be found on the <a href="/minting.php">minting page</a>.
 					</p>
 					<p>
-					    Just like proof-of-work blocks, proof-of-stake blocks generate currency rewards. To generate proof-of-stake blocks, a user sends already-possessed coins to himself in exchange for a preset reward. This reward is currently set at about 1% per year. These transactions increase the "consumed coin age" of the blockchain, a property that Peercoin uses to determine the trustworthiness of the blockchain.</p>
+					    Just like proof-of-work blocks, proof-of-stake blocks generate currency rewards. To generate proof-of-stake blocks, a user sends already-possessed coins to him in exchange for a preset reward. This reward is currently set at about 1% per year. These transactions increase the "consumed coin age" of the blockchain, a property that Peercoin uses to determine the trustworthiness of the blockchain.</p>
 				</div>
 			</div>
 


### PR DESCRIPTION
pronouns ending in "self" are used in conjunction with a noun, as in "Andrew himself" or when the pronoun refers back to the subject, as in "I hit myself." Use "own" in conjunction with a pronoun only when referring back to the subject.

Instead of: They heard herself on the radio.
Consider: They heard her on the radio
