### PR TITLE
Remove gendered pronouns & correct small spanish translation.

### DIFF
--- a/bitaddress.html
+++ b/bitaddress.html
@@ -5210,7 +5210,7 @@
 					"brainalertpassphrasedoesnotmatch": "Las contraseñas no coinciden.",
 					"detailalertnotvalidprivatekey": "El texto que has introducido no es una clave privada válida",
 					"detailconfirmsha256": "El texto que has introducido no es una clave privada válida\n\n¿Quieres usar ese texto como si fuera una contraseña y generar una clave privada usando un hash SHA256 de tal contraseña?\n\nAviso: Es importante escoger una contraseña fuerte para evitar ataques de fuerza bruta a fin de adivinarla y robar tus bitcoins.",
-					"vanityinvalidinputcouldnotcombinekeys": "Entrada no válida. No se puede combinar llaves.",
+					"vanityinvalidinputcouldnotcombinekeys": "Entrada no válida. No se puede combinar claves.",
 					"vanityalertinvalidinputpublickeysmatch": "Entrada no válida. La clave pública de ambos coincidan entradas. Debe introducir dos claves diferentes.",
 					"vanityalertinvalidinputcannotmultiple": "Entrada no válida. No se puede multiplicar dos claves públicas. Seleccione 'Añadir' para agregar dos claves públicas para obtener una dirección bitcoin.",
 					"vanityprivatekeyonlyavailable": "Sólo está disponible cuando se combinan dos claves privadas",

--- a/index.php
+++ b/index.php
@@ -117,7 +117,7 @@
 				    <div id="collapseTwo" class="panel-collapse collapse">
 				      <div class="panel-body">
 				        <p>Generating blocks through the hybrid proof-of-work/proof-of-stake algorithm reduces the risk of the Selfish-Miner Cornell Flaw, ">50%" attacks, and the block bloating that have been used to exploit other currencies.</p>
-						<p>The proof-of-stake portion of the algorithm stands at the heart of this security because it drastically raises the cost of an attack. Acquiring 51% of all existing coins requires more effort and resources than acquiring 51% of all mining power. Further, in a ">50%" stake attack, the attacker's investment will be, by definition, at risk of great loss because the attacker will be holding a majority of the coins that he or she is attacking. This risk of loss reduces the incentive to attempt such an attack in the first place.</p>
+						<p>The proof-of-stake portion of the algorithm stands at the heart of this security because it drastically raises the cost of an attack. Acquiring 51% of all existing coins requires more effort and resources than acquiring 51% of all mining power. Further, in a ">50%" stake attack, the attacker's investment will be, by definition, at risk of great loss because the attacker will be holding a majority of the coins that they are attacking. This risk of loss reduces the incentive to attempt such an attack in the first place.</p>
 						<p>Peercoin also employs other advanced security features including enforcing transaction fees at protocol level to defend against block bloating attacks.</p>
 				      </div>
 				    </div>


### PR DESCRIPTION
While 'he or she' is preferable to simply 'he', 'they' is unambiguously gender neutral; moreover, it is more concise, equally understandable, and respectful of people who identify themselves through other gendered pronouns.
