### PR TITLE
you should not use a comma here

### DIFF
--- a/mining.php
+++ b/mining.php
@@ -10,7 +10,7 @@
 
 			<div class="col-lg-6">
 				<p>
-					Peercoin is a hybrid Proof-Of-Work / Proof-Of-Stake coin that uses the same proof-of-work algorithm as Bitcoin. This means you can mine Peercoin with GPUs, FGPAs and ASICs using Bitcoin mining software. Through Peercoin's increasing popularity, the transition to proof-of-stake, and the decreasing return on mining, competition for blocks becomes more fierce.
+					Peercoin is a hybrid Proof-Of-Work / Proof-Of-Stake coin that uses the same proof-of-work algorithm as Bitcoin. This means you can mine Peercoin with GPUs, FGPAs and ASICs using Bitcoin mining software. Through Peercoin's increasing popularity, the transition to proof-of-stake and the decreasing return on mining, competition for blocks becomes more fierce.
 				</p>
 			</div>
 


### PR DESCRIPTION
Comma Use
If you are using a conjunction to connect only two items, it is incorrect to use a comma before the conjunction. In addition, if you are using a conjunction to add a phrase that cannot stand alone as a complete sentence, it is incorrect to use a comma before the conjunction.

Instead of: Meng, and Kim are hiking across Ireland.
Consider: Meng and Kim are hiking across Ireland.

Instead of: Two books of fiction, and a book of poetry were on the table.
Consider: Two books of fiction and a book of poetry were on the table.
