### PR TITLE
Removed PHP extension from URLs

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,10 @@
+RewriteEngine	On
+
+# Quick and dirty URL rewrites for each page
+RewriteRule		^mining$			mining.php			[NC]
+RewriteRule		^minting$			minting.php			[NC]
+RewriteRule		^buying$			buying.php			[NC]
+RewriteRule		^resources$			resources.php		[NC]
+RewriteRule		^downloads$			downloads.php		[NC]
+RewriteRule		^interview$			interview.php		[NC]
+RewriteRule		^whitepaper$		whitepaper.php		[NC]

--- a/footer.php
+++ b/footer.php
@@ -9,13 +9,13 @@
 				<ul>
 					<li>
 						<div class="ch-item ch-img-1">
-							<a href="downloads.php">
+							<a href="downloads">
 								<div class="ch-info">
 									<h3>Installing a Wallet</h3>
 								</div>
 							</a>
 						</div><!-- /ch-img-1 -->
-						<h4><a href="downloads.php">Installing a Wallet</a></h4>
+						<h4><a href="downloads">Installing a Wallet</a></h4>
 					</li>
 				</ul>
 			</div><!-- /col-lg-4 -->
@@ -24,13 +24,13 @@
 				<ul>
 					<li>
 						<div class="ch-item ch-img-2">
-							<a href="downloads.php#config">
+							<a href="downloads#config">
 								<div class="ch-info">
 									<h3>Setting Up Wallet</h3>
 								</div>
 							</a>
 						</div><!-- /ch-img-1 -->
-						<h4><a href="downloads.php#config">Setting Up Wallet</a></h4>
+						<h4><a href="downloads#config">Setting Up Wallet</a></h4>
 					</li>
 			</div><!-- /col-lg-4 -->
 

--- a/header.php
+++ b/header.php
@@ -59,7 +59,7 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </button>
-          <a class="navbar-brand" href="index.php">
+          <a class="navbar-brand" href="/">
             <img src="assets/images/logos/Dark-Text-350.png" width="110" alt="Peercoin">
             <span>The Secure &amp; Sustainable Cryptocoin</span>
           </a>
@@ -70,9 +70,9 @@
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown">Docs <b class="caret"></b></a>
               <ul class="dropdown-menu">
-                <li><a href="whitepaper.php">Peercoin Whitepaper</a></li>
+                <li><a href="whitepaper">Peercoin Whitepaper</a></li>
                 <li><a href="https://github.com/ppcoin/ppcoin/wiki">Wiki</a></li>
-                <li><a href="resources.php">List of Resources</a></li>
+                <li><a href="resources">List of Resources</a></li>
               </ul>
             </li>
             <li class="dropdown">
@@ -85,21 +85,21 @@
                 ?>
                 <li><a href="mailto:sunnyking9999@gmail.com?cc=john.manglaviti@gmail.com&subject=Sunny%20King%20Interview%20Request">Interview Sunny King</a></li>
                 <?php } else { ?>
-                <li><a href="/interview.php">Interview Sunny King</a></li>
+                <li><a href="/interview">Interview Sunny King</a></li>
                 <?php } ?>
               </ul>
             </li>
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown">Get Peercoins <b class="caret"></b></a>
               <ul class="dropdown-menu">
-		    <li><a href="mining.php">Mine Peercoins</a></li>
-		    <li><a href="minting.php">Mint Peercoins</a></li>
-		    <li><a href="buying.php">Buy Peercoins</a></li>
+		    <li><a href="mining">Mine Peercoins</a></li>
+		    <li><a href="minting">Mint Peercoins</a></li>
+		    <li><a href="buying">Buy Peercoins</a></li>
               </ul>
             </li>
             <li><a href="https://docs.google.com/forms/d/1uJbNEJThRc3TqnwbVVrd__UQWVUOOr4QSEMbMIIF--s/viewform">Contribute</a></li>
             <li><a href="http://www.peercointalk.org/">Forum</a></li>
-            <li class="wallet"><a class="btn btn-primary btn-lg" role="button" href="downloads.php" target="_blank">Download Wallet!</a></li>
+            <li class="wallet"><a class="btn btn-primary btn-lg" role="button" href="downloads" target="_blank">Download Wallet!</a></li>
           </ul>
         </div><!--/.nav-collapse -->
       </div>

--- a/index.php
+++ b/index.php
@@ -9,7 +9,7 @@
 		          <span><strong>Peercoin</strong> is here.</span>
 		        </h1>
 				<a href="#cta" class="btn btn-embossed btn-primary smoothScroll">Why Peercoin?</a>
-		        <a href="downloads.php" target="_blank" class="btn btn-embossed btn-primary">Download Wallet!</a>
+		        <a href="downloads" target="_blank" class="btn btn-embossed btn-primary">Download Wallet!</a>
 
 		        <div class="marketcap">
 			        <ul>
@@ -220,7 +220,7 @@
 				<h4>Convinced <b>you</b>?</h4>
 			    	<p>Time to download the client, and try it yourself. If you have any questions just ask on the
 			    		<a href="http://www.peercointalk.org/">forum</a>, or the social links below.</p>
-			        <a href="downloads.php" class="btn btn-primary btn-large"><i class="fui-link"></i> Download Wallet!</a>
+			        <a href="downloads" class="btn btn-primary btn-large"><i class="fui-link"></i> Download Wallet!</a>
 			        <div class="social">
 			<a href="https://www.facebook.com/Peercoin"><img src="assets/img/icons/social-fb.png" alt="Visit us on Facebook"></a>
 			<a href="http://www.reddit.com/r/peercoin"><img src="assets/img/icons/social-reddit.png" alt="Reddit"></a>

--- a/mining.php
+++ b/mining.php
@@ -26,14 +26,14 @@
 				<div class="item">
 					<p>
 						<strong>Setting up the PPC wallet</strong><br />
-						Download the Peercoin wallet if you did not do this already. Install, let it sync, and secure the wallet with a good password. You can find your wallet address on the receive tab. You can follow <a href="http://peercoin.net/downloads.php">this guide</a> to download and configure it.
+						Download the Peercoin wallet if you did not do this already. Install, let it sync, and secure the wallet with a good password. You can find your wallet address on the receive tab. You can follow <a href="http://peercoin.net/downloads">this guide</a> to download and configure it.
 					</p>
 				</div>
 
 				<div class="item">
 					<p>
 						<strong>Sign Up in a Pool</strong><br />
-						You can find a list of pools in the <a href="http://peercoin.net/resources.php">resources page</a>. Here you can find instructions to join some of these pools.
+						You can find a list of pools in the <a href="http://peercoin.net/resources">resources page</a>. Here you can find instructions to join some of these pools.
 					</p>
 				</div>
 				<div class="panel-group" id="accordion">


### PR DESCRIPTION
This commit works fine, i.e. no errors and routes everything properly.

Unfortunately, without using something a PHP router, I don't think we'll be able to use the 301 redirect technique.

If that's something you want to do, we can look into it. Otherwise, I don't think the 301s will be that important anyway. The old `*.php` extension URLs will still work perfectly, but now the pages point to the URLs without the extension, meaning the `*.php` will slowly be replaced in page rank by the new form.

I refunded the last commit tip because it didn't work and it felt wrong to me to get paid for a bad contribution, tx: https://blockchain.info/tx/955d9ed2a1469fcb8f0b9a9240d193e1292590380840c3cf177d6a9b194c8e6c

Hopefully this one works just as well as the last one I intended to.
