### PR TITLE
fix header and footer to work with all pages

### DIFF
--- a/header.php
+++ b/header.php
@@ -1,3 +1,8 @@
+<?php
+  include ('locale/locale.php');
+  $Locale = new Locale();
+?>
+
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/index.php
+++ b/index.php
@@ -1,8 +1,3 @@
-<?php
-	include ('locale/locale.php');
-	$Locale = new Locale();
-?>
-
 <?php include ('header.php'); ?>
 
   <!-- Headerwrap -->


### PR DESCRIPTION
Header didn't work for pages other than index.php, now both header and footer appears as they should in pages such as mining.php
I started this because the menu drop down didn't appear on pages such as mining.php.
