### PR TITLE
Make header translatable and organize strings.php

### DIFF
--- a/assets/js/ticker.js
+++ b/assets/js/ticker.js
@@ -12,11 +12,11 @@ $(document).ready(function() {
             if (intervalId == null) {
                 intervalId = setInterval(function() {
                     secondsSinceUpdate++;
-                    var secondUnit = "seconds";
+                    var secondUnit = secondsText;
                     if (secondsSinceUpdate == 1) {
-                      secondUnit = "second";
+                      secondUnit = secondText;
                     }
-                    $('#seconds-since-update').text(secondsSinceUpdate + " " + secondUnit + " ago");
+                    $('#seconds-since-update').text(secondsSinceUpdate + " " + secondUnit);
                 }, 1000);
             }
             $('#current-price').text("$" + data['price'] + " USD/PPC");

--- a/footer.php
+++ b/footer.php
@@ -69,6 +69,10 @@
     <script src="assets/js/jquery.js"></script>
     <script src="assets/js/bootstrap.min.js"></script>
     <script src="assets/js/retina.js"></script>
+    <script type="text/javascript">
+        var secondText = "<?php echo $Locale->getText("second_ago"); ?>";
+        var secondsText = "<?php echo $Locale->getText("seconds_ago"); ?>";
+    </script>
     <script src="assets/js/ticker.js"></script>
 	<script src="assets/js/jquery.themepunch.revolution.min.js"></script>
 	<script src="assets/js/jquery.themepunch.plugins.min.js"></script>

--- a/header.php
+++ b/header.php
@@ -8,7 +8,7 @@
   <head>
 	<meta charset="UTF-8">
 	<!-- Title here -->
-	<title>Peercoin - The Secure &amp; Sustainable Cryptocoin.</title>
+	<title><?php echo $Locale->getText("homepage_title"); ?></title>
 
 	<!-- Description, Keywords and Author -->
 	<meta name="description" content="Peercoin - the secure and sustainable cryptocoin." />
@@ -66,48 +66,48 @@
           </button>
           <a class="navbar-brand" href="/">
             <img src="assets/images/logos/Dark-Text-350.png" width="110" alt="Peercoin">
-            <span>The Secure &amp; Sustainable Cryptocoin</span>
+            <span><?php echo $Locale->getText("homepage_title"); ?></span>
           </a>
         </div>
         <div class="navbar-collapse collapse">
           <ul class="nav navbar-nav pull-right">
 
             <li class="dropdown">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown">Docs &amp; Press<b class="caret"></b></a>
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown"><?php echo $Locale->getText("dropdown_title_docs_and_press"); ?><b class="caret"></b></a>
               <ul class="dropdown-menu">
-                <li><a href="whitepaper">Peercoin Whitepaper</a></li>
-                <li><a href="https://github.com/ppcoin/ppcoin/wiki">Wiki (Github)</a></li>
-                <li><a href="http://www.peercointalk.org/index.php?topic=1616.0">Press Kit</a></li>
-                <li><a href="http://www.peercointalk.org/index.php?topic=2219.0">Articles and Interviews</a></li>
+                <li><a href="whitepaper"><?php echo $Locale->getText("dropdown_docs_and_press_whitepaper"); ?></a></li>
+                <li><a href="https://github.com/ppcoin/ppcoin/wiki"><?php echo $Locale->getText("dropdown_docs_and_press_wiki"); ?></a></li>
+                <li><a href="http://www.peercointalk.org/index.php?topic=1616.0"><?php echo $Locale->getText("dropdown_docs_and_press_kit"); ?></a></li>
+                <li><a href="http://www.peercointalk.org/index.php?topic=2219.0"><?php echo $Locale->getText("dropdown_docs_and_press_articles_interviews"); ?></a></li>
                 <?php
                 if (!file_exists('include/recaptcha_keys.php')) {
                 ?>
-                 <li><a href="mailto:sunnyking9999@gmail.com?cc=john.manglaviti@gmail.com&amp;subject=Sunny%20King%20Interview%20Request">Interview Sunny King</a></li>
+                 <li><a href="mailto:sunnyking9999@gmail.com?cc=john.manglaviti@gmail.com&amp;subject=Sunny%20King%20Interview%20Request"><?php echo $Locale->getText("dropdown_docs_and_press_sunny_king_interview"); ?></a></li>
                 <?php } else { ?>
-                <li><a href="interview">Interview Sunny King</a></li>
+                <li><a href="interview"><?php echo $Locale->getText("dropdown_docs_and_press_sunny_king_interview"); ?></a></li>
                 <?php } ?>
               </ul>
             </li>
-            <li><a href="http://peercoin.net/resources">Use Peercoins</a></li>
+            <li><a href="http://peercoin.net/resources"><?php echo $Locale->getText("dropdown_title_use_peercoins"); ?></a></li>
             <li class="dropdown">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown">Get Peercoins <b class="caret"></b></a>
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown"><?php echo $Locale->getText("dropdown_title_peercoins"); ?> <b class="caret"></b></a>
               <ul class="dropdown-menu">
-		            <li><a href="mining">Mine Peercoins</a></li>
-        		    <li><a href="minting">Mint Peercoins</a></li>
-        		    <li><a href="buying">Buy Peercoins</a></li>
+		            <li><a href="mining"><?php echo $Locale->getText("dropdown_peercoins_mine"); ?></a></li>
+        		    <li><a href="minting"><?php echo $Locale->getText("dropdown_peercoins_mint"); ?></a></li>
+        		    <li><a href="buying"><?php echo $Locale->getText("dropdown_peercoins_buy"); ?></a></li>
                 <li><a href="http://peer4commit.com">Peer4commit</a></li>
               </ul>
             </li>
             <li class="dropdown">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown">Contribute <b class="caret"></b></a>
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown"><?php echo $Locale->getText("dropdown_title_contribute"); ?> <b class="caret"></b></a>
               <ul class="dropdown-menu">
-                <li><a href="https://docs.google.com/forms/d/1uJbNEJThRc3TqnwbVVrd__UQWVUOOr4QSEMbMIIF--s/viewform">Volunteer</a></li>
-                <li><a href="participate">Participate</a>
+                <li><a href="https://docs.google.com/forms/d/1uJbNEJThRc3TqnwbVVrd__UQWVUOOr4QSEMbMIIF--s/viewform"><?php echo $Locale->getText("dropdown_contribute_volunteer"); ?></a></li>
+                <li><a href="participate"><?php echo $Locale->getText("dropdown_contribute_participate"); ?></a>
                 <!-- TODO: add more ways to contribute and support the Peercoin community -->
               </ul>
             </li>
             <li><a href="http://www.peercointalk.org/">Forum</a></li>
-            <li class="wallet"><a class="btn btn-primary btn-lg" role="button" href="downloads">Download Wallet!</a></li>
+            <li class="wallet"><a class="btn btn-primary btn-lg" role="button" href="downloads"><?php echo $Locale->getText("download_wallet"); ?>!</a></li>
           </ul>
         </div><!--/.nav-collapse -->
       </div>

--- a/locale/strings.php
+++ b/locale/strings.php
@@ -1,429 +1,557 @@
 <?php
 
-$locale_strings['en']['languages'] = "Languages: ";
+//title
+
+$locale_strings['en']['homepage_title'] = "Peercoin - The Secure &amp; Sustainable Cryptocoin.";
+$locale_strings['fr']['homepage_title'] = "Peercoin - The Secure &amp; Sustainable Cryptocoin.";
+$locale_strings['es']['homepage_title'] = "Peercoin - The Secure &amp; Sustainable Cryptocoin.";
+$locale_strings['gr']['homepage_title'] = "Peercoin - Το ασφαλές &amp; Ανεκτό Κρυπτονόμισμα.";
+$locale_strings['cat']['homepage_title'] = "Peercoin - The Secure &amp; Sustainable Cryptocoin.";
+$locale_strings['zh']['homepage_title'] = "Peercoin - The Secure &amp; Sustainable Cryptocoin.";
+
+//dropdown menu (header)
+
+$locale_strings['en']['dropdown_title_docs_and_press'] = "Docs";
+$locale_strings['fr']['dropdown_title_docs_and_press'] = "Docs";
+$locale_strings['es']['dropdown_title_docs_and_press'] = "Docs";
+$locale_strings['gr']['dropdown_title_docs_and_press'] = "Έγγραφα";
+$locale_strings['cat']['dropdown_title_docs_and_press'] = "Docs";
+$locale_strings['zh']['dropdown_title_docs_and_press'] = "Docs";
+
+$locale_strings['en']['dropdown_docs_and_press_whitepaper'] = "Peercoin Whitepaper";
+$locale_strings['fr']['dropdown_docs_and_press_whitepaper'] = "Peercoin Whitepaper";
+$locale_strings['es']['dropdown_docs_and_press_whitepaper'] = "Peercoin Whitepaper";
+$locale_strings['gr']['dropdown_docs_and_press_whitepaper'] = "Το Whitepaper του Peercoin";
+$locale_strings['cat']['dropdown_docs_and_press_whitepaper'] = "Peercoin Whitepaper";
+$locale_strings['zh']['dropdown_docs_and_press_whitepaper'] = "Peercoin Whitepaper";
+
+$locale_strings['en']['dropdown_docs_and_press_wiki'] = "Wiki (Github)";
+$locale_strings['fr']['dropdown_docs_and_press_wiki'] = "Wiki (Github)";
+$locale_strings['es']['dropdown_docs_and_press_wiki'] = "Wiki (Github)";
+$locale_strings['gr']['dropdown_docs_and_press_wiki'] = "Βίκι (Github)";
+$locale_strings['cat']['dropdown_docs_and_press_wiki'] = "Wiki (Github)";
+$locale_strings['zh']['dropdown_docs_and_press_wiki'] = "Wiki (Github)";
+
+$locale_strings['en']['dropdown_docs_and_press_resources'] = "List of Resources";
+$locale_strings['fr']['dropdown_docs_and_press_resources'] = "List of Resources";
+$locale_strings['es']['dropdown_docs_and_press_resources'] = "List of Resources";
+$locale_strings['gr']['dropdown_docs_and_press_resources'] = "Λίστα Πόρων";
+$locale_strings['cat']['dropdown_docs_and_press_resources'] = "List of Resources";
+$locale_strings['zh']['dropdown_docs_and_press_resources'] = "List of Resources";
+
+$locale_strings['en']['dropdown_docs_and_press_kit'] = "Press Kit";
+$locale_strings['fr']['dropdown_docs_and_press_kit'] = "Press Kit";
+$locale_strings['es']['dropdown_docs_and_press_kit'] = "Press Kit";
+$locale_strings['gr']['dropdown_docs_and_press_kit'] = "Συλλογή Τύπου";
+$locale_strings['cat']['dropdown_docs_and_press_kit'] = "Press Kit";
+$locale_strings['zh']['dropdown_docs_and_press_kit'] = "Press Kit";
+
+$locale_strings['en']['dropdown_docs_and_press_articles'] = "Articles and Interviews";
+$locale_strings['fr']['dropdown_docs_and_press_articles'] = "Articles and Interviews";
+$locale_strings['es']['dropdown_docs_and_press_articles'] = "Articles and Interviews";
+$locale_strings['gr']['dropdown_docs_and_press_articles'] = "Άρθρα και Συνεντεύξεις";
+$locale_strings['cat']['dropdown_docs_and_press_articles'] = "Articles and Interviews";
+$locale_strings['zh']['dropdown_docs_and_press_articles'] = "Articles and Interviews";
+
+$locale_strings['en']['dropdown_docs_and_press_sunny_king_interview'] = "Interview Sunny King";
+$locale_strings['fr']['dropdown_docs_and_press_sunny_king_interview'] = "Interview Sunny King";
+$locale_strings['es']['dropdown_docs_and_press_sunny_king_interview'] = "Interview Sunny King";
+$locale_strings['gr']['dropdown_docs_and_press_sunny_king_interview'] = "Πάρε συνέντευξη από τον Sunny King";
+$locale_strings['cat']['dropdown_docs_and_press_sunny_king_interview'] = "Interview Sunny King";
+$locale_strings['zh']['dropdown_docs_and_press_sunny_king_interview'] = "Interview Sunny King";
+
+$locale_strings['en']['dropdown_title_use_peercoins'] = "Use Peercoins";
+$locale_strings['fr']['dropdown_title_use_peercoins'] = "Use Peercoins";
+$locale_strings['es']['dropdown_title_use_peercoins'] = "Use Peercoins";
+$locale_strings['gr']['dropdown_title_use_peercoins'] = "Χρησιμοποίησε Peercoins";
+$locale_strings['cat']['dropdown_title_use_peercoins'] = "Use Peercoins";
+$locale_strings['zh']['dropdown_title_use_peercoins'] = "Use Peercoins";
+
+$locale_strings['en']['dropdown_title_peercoins'] = "Get Peercoins";
+$locale_strings['fr']['dropdown_title_peercoins'] = "Get Peercoins";
+$locale_strings['es']['dropdown_title_peercoins'] = "Get Peercoins";
+$locale_strings['gr']['dropdown_title_peercoins'] = "Πάρε Peercoins";
+$locale_strings['cat']['dropdown_title_peercoins'] = "Get Peercoins";
+$locale_strings['zh']['dropdown_title_peercoins'] = "Get Peercoins";
+
+$locale_strings['en']['dropdown_peercoins_mine'] = "Mine Peercoins";
+$locale_strings['fr']['dropdown_peercoins_mine'] = "Mine Peercoins";
+$locale_strings['es']['dropdown_peercoins_mine'] = "Mine Peercoins";
+$locale_strings['gr']['dropdown_peercoins_mine'] = "Εξόρυξε Peercoins";
+$locale_strings['cat']['dropdown_peercoins_mine'] = "Mine Peercoins";
+$locale_strings['zh']['dropdown_peercoins_mine'] = "Mine Peercoins";
+
+$locale_strings['en']['dropdown_peercoins_mint'] = "Mint Peercoins";
+$locale_strings['fr']['dropdown_peercoins_mint'] = "Mint Peercoins";
+$locale_strings['es']['dropdown_peercoins_mint'] = "Mint Peercoins";
+$locale_strings['gr']['dropdown_peercoins_mint'] = "Κόψε Peercoins";
+$locale_strings['cat']['dropdown_peercoins_mint'] = "Mint Peercoins";
+$locale_strings['zh']['dropdown_peercoins_mint'] = "Mint Peercoins";
+
+$locale_strings['en']['dropdown_peercoins_buy'] = "Buy Peercoins";
+$locale_strings['fr']['dropdown_peercoins_buy'] = "Buy Peercoins";
+$locale_strings['es']['dropdown_peercoins_buy'] = "Buy Peercoins";
+$locale_strings['gr']['dropdown_peercoins_buy'] = "Αγόρασε Peercoins";
+$locale_strings['cat']['dropdown_peercoins_buy'] = "Buy Peercoins";
+$locale_strings['zh']['dropdown_peercoins_buy'] = "Buy Peercoins";
+
+$locale_strings['en']['dropdown_title_contribute'] = "Contribute";
+$locale_strings['fr']['dropdown_title_contribute'] = "Contribute";
+$locale_strings['es']['dropdown_title_contribute'] = "Contribute";
+$locale_strings['gr']['dropdown_title_contribute'] = "Συνέβαλε";
+$locale_strings['cat']['dropdown_title_contribute'] = "Contribute";
+$locale_strings['zh']['dropdown_title_contribute'] = "Contribute";
+
+$locale_strings['en']['dropdown_contribute_volunteer'] = "Volunteer";
+$locale_strings['fr']['dropdown_contribute_volunteer'] = "Volunteer";
+$locale_strings['es']['dropdown_contribute_volunteer'] = "Volunteer";
+$locale_strings['gr']['dropdown_contribute_volunteer'] = "Εθελοντική Εργασία";
+$locale_strings['cat']['dropdown_contribute_volunteer'] = "Volunteer";
+$locale_strings['zh']['dropdown_contribute_volunteer'] = "Volunteer";
+
+$locale_strings['en']['dropdown_contribute_participate'] = "Participate";
+$locale_strings['fr']['dropdown_contribute_participate'] = "Participate";
+$locale_strings['es']['dropdown_contribute_participate'] = "Participate";
+$locale_strings['gr']['dropdown_contribute_participate'] = "Συμμετοχή";
+$locale_strings['cat']['dropdown_contribute_participate'] = "Participate";
+$locale_strings['zh']['dropdown_contribute_participate'] = "Participate";
+
+//main body
+
 $locale_strings['en']['download_wallet'] = "Download Wallet";
-$locale_strings['en']['price'] = "Price";
-$locale_strings['en']['market_cap'] = "Market Cap";
-$locale_strings['en']['total_supply'] = "Total Supply";
+$locale_strings['fr']['download_wallet'] = "Télécharger le Portefeuille";
+$locale_strings['es']['download_wallet'] = "Descargar Monedero";
+$locale_strings['gr']['download_wallet'] = "Κατέβασε το Πορτοφόλι";
+$locale_strings['cat']['download_wallet'] = "Descarregar Moneder";
+$locale_strings['zh']['download_wallet'] = "下载钱包";
+
 $locale_strings['en']['big_welcome_header'] = "Secure. Sustainable. <span><strong>Peercoin</strong> is here.</span>";
-$locale_strings['en']['ticker_last_updated'] = "Last updated: ";
-$locale_strings['en']['ticker_last_updated_never'] = "never";
+$locale_strings['fr']['big_welcome_header'] = "Sûr. Durable. <span><strong>Peercoin</strong> est ici.</span>";
+$locale_strings['es']['big_welcome_header'] = "Seguro. Sostenible. <span><strong>Peercoin</strong> está aquí.</span>";
+$locale_strings['gr']['big_welcome_header'] = "Ασφαλές. Ανεκτό. Το <span><strong>Peercoin</strong> είναι εδώ.</span>";
+$locale_strings['cat']['big_welcome_header'] = "Segur. Sostenible. <span><strong>Peercoin</strong> és aquí.</span>";
+$locale_strings['zh']['big_welcome_header'] = "安全的. 可持续的. <span><strong>点点币</strong> 就在这里.</span>";
 
 $locale_strings['en']['why_peercoin_header_innovation'] = "Original <b>Innovation</b>";
+$locale_strings['fr']['why_peercoin_header_innovation'] = "<b>Innovation</b> originale";
+$locale_strings['es']['why_peercoin_header_innovation'] = "<b>Innovación</b> original";
+$locale_strings['gr']['why_peercoin_header_innovation'] = "Πρωτότυπη <b>Καινοτομία</b>";
+$locale_strings['cat']['why_peercoin_header_innovation'] = "<b>Innovació</b> original";
+$locale_strings['zh']['why_peercoin_header_innovation'] = "原创 <b>革新</b>";
+
+$locale_strings['en']['price'] = "Price";
+$locale_strings['fr']['price'] = "Prix";
+$locale_strings['es']['price'] = "Precio";
+$locale_strings['gr']['price'] = "Τιμή";
+$locale_strings['cat']['price'] = "Preu";
+$locale_strings['zh']['price'] = "价格";
+
+$locale_strings['en']['market_cap'] = "Market Cap";
+$locale_strings['fr']['market_cap'] = "Masse monétaire";
+$locale_strings['es']['market_cap'] = "Capitalización total";
+$locale_strings['gr']['market_cap'] = "Κεφαλαιοποίηση";
+$locale_strings['cat']['market_cap'] = "Capitalització total";
+$locale_strings['zh']['market_cap'] = "市值";
+
+$locale_strings['en']['total_supply'] = "Total Supply";
+$locale_strings['fr']['total_supply'] = "Quantité totale";
+$locale_strings['es']['total_supply'] = "Suministro total";
+$locale_strings['gr']['total_supply'] = "Συνολική Προσφορά";
+$locale_strings['cat']['total_supply'] = "Subministrament total";
+$locale_strings['zh']['total_supply'] = "供应量";
+
+$locale_strings['en']['ticker_last_updated'] = "Last updated: ";
+$locale_strings['fr']['ticker_last_updated'] = "Dernière mise à jour: ";
+$locale_strings['es']['ticker_last_updated'] = "Última actualización: ";
+$locale_strings['gr']['ticker_last_updated'] = "Τελευταία ενημέρωση: ";
+$locale_strings['cat']['ticker_last_updated'] = "Darrera actualització: ";
+$locale_strings['zh']['ticker_last_updated'] = "最后更新: ";
+
+$locale_strings['en']['ticker_last_updated_never'] = "never";
+$locale_strings['fr']['ticker_last_updated_never'] = "jamais";
+$locale_strings['es']['ticker_last_updated_never'] = "nunca";
+$locale_strings['gr']['ticker_last_updated_never'] = "ποτέ";
+$locale_strings['cat']['ticker_last_updated_never'] = "mai";
+$locale_strings['zh']['ticker_last_updated_never'] = "从未";
+
 $locale_strings['en']['why_peercoin_desc_innovation'] = "Peercoin's original innovation is the <a href='/bin/peercoin-paper.pdf'>proof-of-stake/proof-of-work hybrid</a> system. Like other <a href='https://en.wikipedia.org/wiki/Cryptocurrency'>cryptocurrencies</a>, initial coins can be mined, but the core network is maintained by coin holders, rather than the fastest <a href='https://en.bitcoin.it/wiki/Pooled_mining'>pool</a>.";
+$locale_strings['fr']['why_peercoin_desc_innovation'] = "L'innovation originale de Peercoin est le système <a href='/bin/peercoin-paper-fr.pdf'>hybride preuve-de-part/preuve-de-travail</a>. Comme d'autres <a href='https://fr.wikipedia.org/wiki/Crypto-monnaie'>crypto-monnaies</a>, la monnaie initiale peut être générée par extraction (minage), mais le coeur du réseau est maintenu par les possesseurs de monnaie, plutôt que par la <a href='https://en.bitcoin.it/wiki/Pooled_mining'>coopérative de mineurs</a> la plus rapide.";
+$locale_strings['es']['why_peercoin_desc_innovation'] = "La innovación original de Peercoin es el sistema <a href='/bin/peercoin-paper-es.pdf'>híbrido proof-of-stake/proof-of-work</a>. Como en otras <a href='https://en.wikipedia.org/wiki/Cryptocurrency'>criptomonedas</a>, las monedas iniciales pueden ser minadas, pero la red principal está mantenida por los propietarios de monedas, en lugar de los <a href='https://en.bitcoin.it/wiki/Pooled_mining'>pools</a> más rápidos.";
+$locale_strings['gr']['why_peercoin_desc_innovation'] = "Η πρωτότυπη καινοτομία του Peercoin είναι το σύστημα του <a href='/bin/peercoin-paper.pdf'>υβρίδιου απόδειξης-της-συμμετοχής/απόδειξης-της-δουλειάς</a>. Όπως άλλα <a href='https://en.wikipedia.org/wiki/Cryptocurrency'>κρυπτονομίσματα</a>, τα αρχικά νομίσματα μπορούν να εξορυχθούν, αλλά ο πυρήνας του δικτύου διαχειρίζεται από τους κάτοχους των κερμάτων, αντί του γρηγορότερoυ <a href='https://en.bitcoin.it/wiki/Pooled_mining'>κοινού ταμείου</a>.";
+$locale_strings['cat']['why_peercoin_desc_innovation'] = "L'innovació original de Peercoin és el sistema <a href='/bin/peercoin-paper-es.pdf'>híbrid proof-of-stake/proof-of-work</a>. Com en d'altres <a href='https://en.wikipedia.org/wiki/Cryptocurrency'>criptomonedes</a>, les monedes inicials poden ser minades, però la xarxa principal és mantenida pels propietaris de monedes, en lloc dels <a href='https://en.bitcoin.it/wiki/Pooled_mining'>pools</a> més ràpids.";
+$locale_strings['zh']['why_peercoin_desc_innovation'] = "点点币的原创<a href='/bin/peercoin-paper.pdf'>proof-of-stake/proof-of-work(股权证明/工作量证明)混合</a>系统.就像其它<a href='https://en.wikipedia.org/wiki/Cryptocurrency'>加密货币</a>一样, 货币可以通过挖矿产生, 但是,整个网络是被持币者维护的，而不是计算能力强大的<a href='https://en.bitcoin.it/wiki/Pooled_mining'>矿池</a>.";
+
 $locale_strings['en']['why_peercoin_header_security'] = "Increased <b>Security</b>";
+$locale_strings['fr']['why_peercoin_header_security'] = "<b>Sécurité</b> accrue";
+$locale_strings['es']['why_peercoin_header_security'] = "Más <b>Seguro</b>";
+$locale_strings['gr']['why_peercoin_header_security'] = "Αυξημένη <b>Ασφάλεια</b>";
+$locale_strings['cat']['why_peercoin_header_security'] = "Més <b>Segur</b>";
+$locale_strings['zh']['why_peercoin_header_security'] = "更强的<b>安全性</b>";
+
 $locale_strings['en']['why_peercoin_desc_security'] = "Maintaining the network through the hybrid proof-of-work/proof-of-stake algorithm reduces the risk of the <a href='http://www.pcworld.com/article/2060840/selfish-miner-attack-could-devastate-bitcoin-researchers-say.html'> Selfish-Miner Flaw</a>, <a href='https://en.bitcoin.it/wiki/Weaknesses'>51% attacks</a>, and the block bloating that have been used to exploit other currencies.";
+$locale_strings['fr']['why_peercoin_desc_security'] = "Maintenir le réseau avec l'algorithme hybride preuve-de-part/preuve-de-travail réduit les risques d'<a href='http://www.pcworld.com/article/2060840/selfish-miner-attack-could-devastate-bitcoin-researchers-say.html'> attaque par mineur égoïste</a>, d'<a href='https://en.bitcoin.it/wiki/Weaknesses'>attaque des 51%</a>, et de congestion de bloc qui ont été utilisées pour exploiter les autres crypto-monnaies.";
+$locale_strings['es']['why_peercoin_desc_security'] = "Manteniendo la red a través del algoritmo híbrido proof-of-work/proof-of-stake, se reduce el riesgo de aprovechamiento del <a href='http://www.pcworld.com/article/2060840/selfish-miner-attack-could-devastate-bitcoin-researchers-say.html'> defecto de Minero Egoísta</a>, los <a href='https://en.bitcoin.it/wiki/Weaknesses'>ataques del 51%</a>, y el hinchado de monedas que se ha usado para atacar a otras monedas.";
+$locale_strings['gr']['why_peercoin_desc_security'] = "Η διαχείρηση του δικτύου μέσω του αλγορίθμου απόδειξης-της-δουλειάς/απόδειξης-της-συμμετοχής μειώνει τον κίνδυνο του <a href='http://www.pcworld.com/article/2060840/selfish-miner-attack-could-devastate-bitcoin-researchers-say.html'>Ελλατώματος του Εγωιστή-Μεταλλωρύχου</a>, <a href='https://en.bitcoin.it/wiki/Weaknesses'>το 51% των επιθέσεων</a>, και το block bloating που έχει χρησιμοποιηθεί για την εκμετάλλευση άλλων νομισμάτων.";
+$locale_strings['cat']['why_peercoin_desc_security'] = "Mantenint la xarxa a través de l'algoritme híbrid proof-of-work/proof-of-stake, es redueix el risc d'aprofitament del <a href='http://www.pcworld.com/article/2060840/selfish-miner-attack-could-devastate-bitcoin-researchers-say.html'> defecte del Miner Egoista</a>, els <a href='https://en.bitcoin.it/wiki/Weaknesses'>atacs del 51%</a>, i l'inflat de monedes que s'ha utilitzat per atacar a d'altres monedes.";
+$locale_strings['zh']['why_peercoin_desc_security'] = "使用股权证明/工作量证明混合算法维护网络，减少了<a href='http://www.pcworld.com/article/2060840/selfish-miner-attack-could-devastate-bitcoin-researchers-say.html'>自私矿工攻击</a>, 和<a href='https://en.bitcoin.it/wiki/Weaknesses'>51%攻击</a>, 而且不易于像其他货币一样被不法之徒危害。";
+
 $locale_strings['en']['why_peercoin_header_efficiency'] = "Energy and Cost <b>Efficiency</b>";
+$locale_strings['fr']['why_peercoin_header_efficiency'] = "<b>Efficacité</b> en terme d'énergie et de coût";
+$locale_strings['es']['why_peercoin_header_efficiency'] = "<b>Eficiencia</b> y reducción del coste energético";
+$locale_strings['gr']['why_peercoin_header_efficiency'] = "Ενεργειακή και Χρηματική <b>Απόδοση</b>";
+$locale_strings['cat']['why_peercoin_header_efficiency'] = "<b>Eficiència</b> i reducció del cost energètic";
+$locale_strings['zh']['why_peercoin_header_efficiency'] = "低<b>能耗</b>";
+
 $locale_strings['en']['why_peercoin_desc_efficiency'] = "Maintaining the network requires far less energy than generating hardware-intensive proof-of-work hashes. Proof-of-stake also does away with the <a href='http://letstalkbitcoin.com/is-bitcoin-overpaying-for-false-security/'> ~$1 billion \"tax\"</a> on the Bitcoin network through proof-of-work blocks.";
+$locale_strings['fr']['why_peercoin_desc_efficiency'] = "Maintenir le réseau demande bien moins d'énergie que la génération intensive de preuves-de-travail (hachages). La preuve-de-part se débarrasse également de <a href='http://letstalkbitcoin.com/is-bitcoin-overpaying-for-false-security/'>\"l'impôt\" d'un milliard de dollars</a> du réseau Bitcoin avec sa preuve-de-travail.";
+$locale_strings['es']['why_peercoin_desc_efficiency'] = "El mantenimiento de la red requiere mucha menos energía que la generación de hashes proof-of-work mediante hardware especializado. El Proof-of-stake también se deshace del <a href='http://letstalkbitcoin.com/is-bitcoin-overpaying-for-false-security/'> \"impuesto\"de ~$1000 millones </a> de la red Bitcoin mediante bloques proof-of-work.";
+$locale_strings['gr']['why_peercoin_desc_efficiency'] = "Η διαχείριση του δικτύου απαιτεί πολύ λιγότερη ενέργεια από την παραγωγή εντατικού υλικού proof-of-work hashes. Η απόδειξη-της-συμμετοχής επίσης ξεφεύγει από το <a href='http://letstalkbitcoin.com/is-bitcoin-overpaying-for-false-security/'> ~$1 δισεκατομμύριο \"φόρο\"</a> του δίκτυου του Bitcoin μέσω των block απόδειξης-της-δουλειάς.";
+$locale_strings['cat']['why_peercoin_desc_efficiency'] = "El manteniment de la xarxa requereix molta menys energia que la generació de hashes proof-of-work mitjançant hardware especialitzat. El Proof-of-stake també es desfà de <a href='http://letstalkbitcoin.com/is-bitcoin-overpaying-for-false-security/'> l'\"impost\"de ~$1000 milions </a> de la xarxa Bitcoin mitjançant els blocs proof-of-work.";
+$locale_strings['zh']['why_peercoin_desc_efficiency'] = "点点币比那些需求大量硬件进行哈希运算的货币要节能环保.股权证明不会出现比特币的<a href='http://letstalkbitcoin.com/is-bitcoin-overpaying-for-false-security/'>十亿美元税金</a>事件";
+
 $locale_strings['en']['why_peercoin_button'] = "Why Peercoin?";
+$locale_strings['fr']['why_peercoin_button'] = "Pourquoi Peercoin?";
+$locale_strings['es']['why_peercoin_button'] = "¿Por qué Peercoin?";
+$locale_strings['gr']['why_peercoin_button'] = "Γιατί Peercoin;";
+$locale_strings['cat']['why_peercoin_button'] = "¿Per què Peercoin?";
+$locale_strings['zh']['why_peercoin_button'] = "为什么选择点点币?";
+
 $locale_strings['en']['why_peercoin_title'] = "Why <span>Peercoin</span>?";
+$locale_strings['fr']['why_peercoin_title'] = "Pourquoi <span>Peercoin</span>?";
+$locale_strings['es']['why_peercoin_title'] = "¿Por qué <span>Peercoin</span>?";
+$locale_strings['gr']['why_peercoin_title'] = "Γιατί <span>Peercoin</span>;";
+$locale_strings['cat']['why_peercoin_title'] = "¿Per què <span>Peercoin</span>?";
+$locale_strings['zh']['why_peercoin_title'] = "为什么选择<span>点点币</span>?";
+
 $locale_strings['en']['why_peercoin_desc'] = "Through an innovative minting algorithm, the Peercoin network consumes far less energy, maintains stronger security, and rewards users in more sustainable ways than other cryptocurrencies.";
+$locale_strings['fr']['why_peercoin_desc'] = "Grâce à un algorithme innovant de création de monnaie, le réseau Peercoin consomme bien moins d'énergie, maintient une meilleure sécurité, et récompense les utilisateurs d'une manière plus durable que les autres crypto-monnaies.";
+$locale_strings['es']['why_peercoin_desc'] = "Mediante un innovativo algoritmo de acuñado, la red Peercoin consume mucha menos energía, tiene una seguridad más fuerte, y recompensa a sus usuarios de una manera más sostenible que otras criptomonedas.";
+$locale_strings['gr']['why_peercoin_desc'] = "Μέσω ενός καινοτόμου αλγορίθμου κοπής νομισμάτων, το δίκτυο του Peercoin καταναλώνει πολύ λιγότερη ενέργεια, διατηρεί υψηλότερη ασφάλεια, και ανταμοίβει του χρήστες με πιο ανεκτούς τρόπους από άλλα κρυπτονομίσματα.";
+$locale_strings['cat']['why_peercoin_desc'] = "Mitjançant un innovatiu algoritme d'encunyament, la xarxa Peercoin consumeix molta menys energia, té una seguretat més forta i recompensa els seus usuaris d'una forma més sostenible que altres criptomonedes.";
+$locale_strings['zh']['why_peercoin_desc'] = "点点币网络通过使用优秀的创新算法，在消耗更少的能源的同时, 提供更好的安全加密。比其他加密货币更能公平的回报用户。";
 
 $locale_strings['en']['fund_peercoin'] = "Fund <span>Peercoin.</span>";
+$locale_strings['fr']['fund_peercoin'] = "Financer <span>Peercoin.</span>";
+$locale_strings['es']['fund_peercoin'] = "Financia <span>Peercoin.</span>";
+$locale_strings['gr']['fund_peercoin'] = "Χρηματοδοτήστε το <span>Peercoin.</span>";
+$locale_strings['cat']['fund_peercoin'] = "Financia <span>Peercoin.</span>";
+$locale_strings['zh']['fund_peercoin'] = "支持 <span>点点币.</span>";
+
 $locale_strings['en']['fund_peercoin_accepting_donations'] = "We are now accepting donations towards the Peercoin Development and Web Fund.";
+$locale_strings['fr']['fund_peercoin_accepting_donations'] = "Nous acceptons maintenant les dons pour le développement de Peercoin et du site web.";
+$locale_strings['es']['fund_peercoin_accepting_donations'] = " Aceptamos donaciones para el desarrollo de Peercoin y la página web.";
+$locale_strings['gr']['fund_peercoin_accepting_donations'] = "Τώρα δεχόμαστε δωρεές μέσω της Ανάπτυξης του Peercoin και της Διαδικτυακής Χρηματοδότησης.";
+$locale_strings['cat']['fund_peercoin_accepting_donations'] = " Aceptem donacions per al dessenvolupament de Peercoin i la plana web.";
+$locale_strings['zh']['fund_peercoin_accepting_donations'] = "我们现在接受捐赠用于点点币的开发和Web基金.";
+
 $locale_strings['en']['fund_peercoin_donations_btc'] = "BTC Donations: ";
+$locale_strings['fr']['fund_peercoin_donations_btc'] = "Dons en BTC: ";
+$locale_strings['es']['fund_peercoin_donations_btc'] = "Donaciones con BTC: ";
+$locale_strings['gr']['fund_peercoin_donations_btc'] = "BTC Δωρεές: ";
+$locale_strings['cat']['fund_peercoin_donations_btc'] = "Donacions amb BTC: ";
+$locale_strings['zh']['fund_peercoin_donations_btc'] = "BTC 捐赠: ";
+
 $locale_strings['en']['fund_peercoin_donations_ppc'] = "PPC Donations: ";
+$locale_strings['fr']['fund_peercoin_donations_ppc'] = "Dons en PPC: ";
+$locale_strings['es']['fund_peercoin_donations_ppc'] = "Donaciones con PPC: ";
+$locale_strings['gr']['fund_peercoin_donations_ppc'] = "PPC Δωρεές: ";
+$locale_strings['cat']['fund_peercoin_donations_ppc'] = "Donacions amb PPC: ";
+$locale_strings['zh']['fund_peercoin_donations_ppc'] = "PPC 捐赠: ";
+
 $locale_strings['en']['block_explorer'] = "Block Explorer";
+$locale_strings['fr']['block_explorer'] = "Explorateur de blocs";
+$locale_strings['es']['block_explorer'] = "Explorador de bloques";
+$locale_strings['gr']['block_explorer'] = "Εξερευνητής Block";
+$locale_strings['cat']['block_explorer'] = "Explorador de blocs";
+$locale_strings['zh']['block_explorer'] = "区块浏览";
 
 $locale_strings['en']['faq_header'] = "Frequently <span>asked questions</span>";
+$locale_strings['fr']['faq_header'] = "<span>Questions</span> fréquemment posées";
+$locale_strings['es']['faq_header'] = "<span>Preguntas</span> frecuentes";
+$locale_strings['gr']['faq_header'] = "Συχνά <span>ερωτήματα</span>";
+$locale_strings['cat']['faq_header'] = "<span>Preguntes</span> freqüents";
+$locale_strings['zh']['faq_header'] = "常见 <span>问题</span>";
+
 $locale_strings['en']['faq_q_title_innovation'] = "Tell me more about Original Innovation.";
-$locale_strings['en']['faq_q_desc_innovation'] = "
-						<p>Peercoin's original and noteworthy innovation is the proof-of-stake/proof-of-work hybrid system.</p>
+$locale_strings['fr']['faq_q_title_innovation'] = "Dites m'en plus à propos de l'Innovation originale.";
+$locale_strings['es']['faq_q_title_innovation'] = "Cuéntame más acerca de la Innovación Original.";
+$locale_strings['gr']['faq_q_title_innovation'] = "Πείτε μου περισσότερα για την Πρωτότυπη Καινοτομία.";
+$locale_strings['cat']['faq_q_title_innovation'] = "Explica'm més sobre l'Innovació Original.";
+$locale_strings['zh']['faq_q_title_innovation'] = "说说你们的创新之处.";
+
+$locale_strings['en']['faq_q_desc_innovation'] = "<p>Peercoin's original and noteworthy innovation is the proof-of-stake/proof-of-work hybrid system.</p>
 						<p>Like other cryptocurrencies, initial coins can be mined through the more commonly used proof-of-work hashing process. However unlike other coins, as the hashing difficulty increases over time, users continue to be rewarded with coins generated by the additional proof-of-stake algorithm. Anyone holding 1% of the currency will be compensated with 1% of all proof-of-stake coin blocks.</p>
 						<p>In addition to increased security and improved energy efficiency, the hybrid proof-of-work/proof-of-stake algorithm combats the deflationary tendencies that cryptocurrencies can suffer because of their hard mintage caps.</p>";
+$locale_strings['fr']['faq_q_desc_innovation'] = "
+						<p>L'innovation originale notable de Peercoin est le système hybride preuve-de-part/preuve-de-travail.</p>
+						<p>Comme d'autres crypto-monnaies, la monnaie initiale peut être extraite par le processus communément utilisé de preuve-de-travail par hachage. Cependant contrairement aux autres monnaies, quand la difficulté d'extraction augmente avec le temps, les utilisateurs continuent à être récompensés avec la monnaie générée par l'algorithme additionnel de preuve-de-part. Une personne détenant 1% de la monnaie sera récompensée par 1% de la monnaie générée par les bloc preuve-de-part.</p>
+						<p>De plus, afin d'accroître la sécurité et l'efficacité énergétique, l'algorithme hybride preuve-de-part/preuve-de-travail combat les tendances déflationnistes dont souffrent les crypto-monnaies ayant une masse monétaire maximale fixée.</p>";
+$locale_strings['es']['faq_q_desc_innovation'] = "
+						<p>La más notoria innovación original de Peercoin es el sistema híbrido proof-of-stake/proof-of-work.</p>
+						<p>Como otras criptomonedas, las monedas iniciales pueden ser minadas con el sistema tradicional de procesado de hashing mediante el proof-of-work. Sin embargo, a diferencia de otras monedas, mientras la dificultad de hashing aumenta con el tiempo, los usuarios continúan siendo recompensados con monedas generadas con el algoritmo adicional del proof-of-stake. Cualquiera que tenga moneda, será recompensado con un 1% del total mediante bloques proof-of-stake.</p>
+						<p>Adicionalmente al aumento de seguridad in la mejorada eficiencia energética, el sistema híbrido del algoritmo proof-of-work/proof-of-stake combate las tendencias deflacionarias que las criptomonedas pueden sufrir debido a su tope de acuñado preestablecido.</p>";
+$locale_strings['gr']['faq_q_desc_innovation'] = "
+						<p>Η πρωτότυπη και αξιοσημείωτη καινοτομία του Peercoin είναι το σύστημα του υβριδίου της απόδειξης-της-συμμετοχής/απόδειξης-της-δουλειάς.</p>
+						<p>Όπως και άλλα κρυπτονομίσματα, τα αρχικά νομίσματα μπορούν να εξορυχθούν μέσω των κοινών απόδειξης-της-δουλειάς hashing διαδικασιών. Παρ'όλα αυτά, σε αντίθεση με τα άλλα νομίσματα, όσο η δυσκολία hashing μεγαλώνει καθώς περνάει ο χρόνος, οι χρήστες συνεχίζουν να ανταμείβονται με νομίσματα τα οποία παράγονται από τον επιπλέον αλγόριθμο της απόδειξης-της-συμμετοχής. Οποιοσδήποτε έχει το 1% του νομίσματος θα αποζημιώνεται με το 1% από όλων των blocks της απόδειξης-της-συμμετοχής.</p>
+						<p>Επιπροσθέτως της αυξανόμενης ασφάλειας και της βελτιωμένης ενεργειακής απόδοσης, ο υβριδικός αλγόριθμος απόδειξης-της-δουλειάς/απόδειξης-της-συμμετοχής καταπολεμά τις αποπληθωριστικές τάσεις από τις οποίες μπορούν να υποφέρουν τα κρυπτονομίσματα λόγω των σκληρών καλυμμάτων νομισματοκοπίας.</p>";
+$locale_strings['cat']['faq_q_desc_innovation'] = "<p>La més notoria innovació original de Peercoin és el sistema híbrid proof-of-stake/proof-of-work.</p>
+						<p>Com d'altres criptomonedes, les monedes inicials poden ser minades amb el sistema tradicional de processat de hashing mitjançant el proof-of-work. No obstant, a diferència d'altres monedes, mentre la dificultat de hashing augmenta amb el temps, els usuaris continuen sent recompensats amb monedes generades amb l'algoritme adicional del proof-of-stake. Cualsevol que tingui moneda, serà recompensat amb un 1% del total mitjançant blocs proof-of-stake.</p>
+						<p>Adicionalment a l'augment de seguretat i la millorada eficiència energética, el sistema híbrid de l'algoritme proof-of-work/proof-of-stake combat les tendencies deflacionaries que les criptomonedes poden patir degut al seu límit d'encunyament preestablert.</p>";
+$locale_strings['zh']['faq_q_desc_innovation'] = "
+						<p>点点币引以自豪的创新之处就是股权证明和工作量证明混合系统.</p>
+						<p>就像其他加密货币, 刚开始，货币通过挖矿产生. 但是,随着挖矿难度的提高,持币者将可以随时间推移而获得利息.例如拥有1%货币的人将可以获得1%利息区块的货币.</p>
+						<p>并且，这还带来了更高的安全加密级别。任何的破解都会变得异常艰难.</p>";
+
 $locale_strings['en']['faq_q_title_security'] = "Tell me more about Increased Security.";
-$locale_strings['en']['faq_q_desc_security'] = "
-						<p>Generating blocks through the hybrid proof-of-work/proof-of-stake algorithm reduces the risk of the Selfish-Miner Cornell Flaw, \">50%\" attacks, and the block bloating that have been used to exploit other currencies.</p>
+$locale_strings['fr']['faq_q_title_security'] = "Dites m'en plus à propos de la Sécuritée accrue.";
+$locale_strings['es']['faq_q_title_security'] = "Cuéntame más acerca de la Seguridad Mejorada.";
+$locale_strings['gr']['faq_q_title_security'] = "Πείτε μου περισσότερα για την Αυξημένη Ασφάλεια.";
+$locale_strings['cat']['faq_q_title_security'] = "Explica'm més sobre la Seguretat Millorada.";
+$locale_strings['zh']['faq_q_title_security'] = "说说你们更强的安全性.";
+
+$locale_strings['en']['faq_q_desc_security'] = "<p>Generating blocks through the hybrid proof-of-work/proof-of-stake algorithm reduces the risk of the Selfish-Miner Cornell Flaw, \">50%\" attacks, and the block bloating that have been used to exploit other currencies.</p>
 						<p>The proof-of-stake portion of the algorithm stands at the heart of this security because it drastically raises the cost of an attack. Acquiring 51% of all existing coins requires more effort and resources than acquiring 51% of all mining power. Further, in a \">50%\" stake attack, the attacker's investment will be, by definition, at risk of great loss because the attacker will be holding a majority of the coins that they are attacking. This risk of loss reduces the incentive to attempt such an attack in the first place.</p>
 						<p>Peercoin also employs other advanced security features including enforcing transaction fees at protocol level to defend against block bloating attacks.</p>";
+$locale_strings['fr']['faq_q_desc_security'] = "<p>Générer les blocs par l'algorithme hybride preuve-de-part/preuve-de-travail réduit les risques d'attaque par mineur égoïste, d'attaque \">50%\", et de congéstion de bloc qui ont été utilisées pour exploiter les autres crypto-monnaies.</p>
+						<p>La portion preuve-de-part de l'algorithme est au coeur de cette sécurité car elle augmente drastiquement le coût d'une attaque. Acquerir 51% de toute la monnaie requiert plus d'efforts et de ressources qu'acquerir 51% de toute la puissance d'extraction. De plus, dans une attaque de part \">50%\", par définition l'attaquant a un fort risque de perdre son investissement, puisqu'il détient la majorité de la monnaie qu'il attaque. Ce risque de perte réduit la motivation à tenter une telle attaque en premier lieu.</p>
+						<p>Peercoin utilise aussi d'autres techniques pour la sécurité, comme les frais de transaction fixés au niveau du protocole pour se défendre contre les attaques par congéstion de bloc.</p>";
+$locale_strings['es']['faq_q_desc_security'] = "
+						<p>La generación de bloques mediante el algoritmo híbrido proof-of-work/proof-of-stake reduce el riesgo del defecto del Minero Egoísta de Cornell, ataques de\">50%\", y el hinchado de bloques que se ha usado para aprovecharse de otras monedas.</p>
+						<p>La porción proof-of-stake del algoritmo está en el corazón de las medidas de seguridad porque aumenta considerablemente el coste de un ataque. Adquirir el 51% de todas las monedas existentes requiere más esfuerzo y recursos que adquirir el 51% de todo el poder de minado. Además, en un ataque stake de \">50%\", la inversión del atacante será, por definición, un gran riesgo de pérdida, porque el atacante tendrá la mayoría de monedas que está atacando. Este riesgo de pérdida reduce el incentivo de intentar ese tipo de ataque en primer lugar.</p>
+						<p>Peercoin también emplea otras medidas de seguridadad avanzadas, como forzar tasas de transacción a nivel de protocolo para defenderse de ataques de hinchado de monedas.</p>";
+$locale_strings['gr']['faq_q_desc_security'] = "
+						<p>Η παραγωγή blocks μέσω του υβριδικού αλγορίθμου απόδειξης-της-συμμετοχής μειώνει τον κίνδυνο του Ελλατώματος του Εγωιστή-Μεταλλωρύχου του Cornell, \">50%\" των επιθέσεων, και το block bloating που έχει χρησιμοποιηθεί για την εκμετάλλευση άλλων νομισμάτων.</p>
+						<p>Το τμήμα του αλγορίθμου που αναφέρεται στην απόδειξη-της-συμμετοχής βρίσκεται στην καρδιά της ασφάλειας επειδή αυξάνει δραστικά το κόστος μιας επίθεσης. Η απόκτηση του 51% από όλα τα υπάρχοντα νομίσματα απαιτεί περισσότερη προσπάθεια και πόρους από όσο η απόκτηση του 51% όλης της δύναμης εξόρυξης. Επιπλέον, σε μία μετοχική επίθεση της τάξης του \">50%\", η επένδυση του εισβολέα θα είναι, εξ ορισμού, σε κίνδυνο τεράστιας απώλειας επειδή ο ίδιος θα έχει στα χέρια του την πλειονότητα των κερμάτων στα οποία επιτίθεται. Αυτός ο κίνδυνος απώλειας μειώνει το κίνητρο του να προσπαθήσει κάποιος μια τέτοια επίθεση εξαρχής.</p>
+						<p>Το Peercoin επίσης χρησιμοποιεί και άλλα προηγμένα χαρακτηριστικά ασφαλείας συμπεριλαμβανομένης της εφαρμογής των τελών συναλλαγής σε επίπεδο πρωτοκόλλου για την υπεράσπιση ενάντια στις block bloating επιθέσεις.</p>";
+$locale_strings['cat']['faq_q_desc_security'] = "
+						<p>La generació de blocs mitjançant l'algoritme híbrid proof-of-work/proof-of-stake redueix el risc del defecte del Miner Egoísta de Cornell, atacs de\">50%\", i l'inflat de blocs que s'ha utilitzat per aprofitar-se d'altres monedes.</p>
+						<p>La porció proof-of-stake de l'algoritme és al cor de les mesures de seguretat perquè augmenta considerablement el cost d'un atac. Adquirir el 51% de totes les monedes existents requereix de més esforç i recursos que adquirir el 51% de tot el poder de minat. Ademés, en un atac stake de \">50%\", l'inversió de l'atacant serà, per definició, un gran risc de pèrdua, perque l'atacant tindrà la major part de les monedes que està atacant. Aquest risc de pèrdua redueix l'incentiu d'intentar aquest tipus d'atac en primer lloc.</p>
+						<p>Peercoin també fa servir altres mesures de seguretat avançades, com forçar tases de transacció a nivell de protocol per defendre's d'atacs d'inflat de monedes.</p>";
+$locale_strings['zh']['faq_q_desc_security'] = "<p>使用股权证明和工作量证明混合算法产生的区块可以避免自私矿工攻击和\">50%\" 攻击,不易于像其他货币一样被不法之徒危害.</p>
+						<p>股权证明算法作为安全加密的核心。它极大地加大了攻击的难度和代价.获得51%的货币远比51%的矿工难多了. 并且在\">50%\"攻击中黑客会有巨大的风险，因为，他有这种货币的绝大多数，他需要自己承担价值受损的风险</p>
+						<p>点点币同时强制了交易税来防止被不法之徒危害.</p>";
+
 $locale_strings['en']['faq_q_title_efficiency'] = "Tell me more about Energy and Cost Efficiency.";
-$locale_strings['en']['faq_q_desc_efficiency'] = "
-						<p>Generating proof-of-stake blocks requires far less energy than generating hardware-intensive proof-of-work hashes. This means that over time, the Peercoin network will consume less energy as proof-of-work blocks become less rewarding and blocks are generated instead by the proof-of-stake portion of the algorithm.</p>
+$locale_strings['fr']['faq_q_title_efficiency'] = "Dites m'en plus à propos de l'Efficacité en terme d'énergie et de coût.";
+$locale_strings['es']['faq_q_title_efficiency'] = "Cuéntame más acerca de la eficiencia energética.";
+$locale_strings['gr']['faq_q_title_efficiency'] = "Πείτε μου περισσότερα για την Αποδοτικότητα της Ενέργειας και του Κόστους.";
+$locale_strings['cat']['faq_q_title_efficiency'] = "Explica'm més sobre l'eficiència energética.";
+$locale_strings['zh']['faq_q_title_efficiency'] = "说说你们的低能耗.";
+
+$locale_strings['en']['faq_q_desc_efficiency'] = "<p>Generating proof-of-stake blocks requires far less energy than generating hardware-intensive proof-of-work hashes. This means that over time, the Peercoin network will consume less energy as proof-of-work blocks become less rewarding and blocks are generated instead by the proof-of-stake portion of the algorithm.</p>
 				        <p>Proof-of-stake also does away with the ~$1 billion 'tax' on the Bitcoin network through proof-of-work blocks. You can read more about that <a href='http://letstalkbitcoin.com/is-bitcoin-overpaying-for-false-security/'>here</a>.</p>";
+$locale_strings['fr']['faq_q_desc_efficiency'] = "
+						<p>Générer des blocs par preuve-de-part nécessite bien moins d'énergie que par la génération intensive de hachages pour la preuve-de-travail. Ceci signifie qu'à long terme, le réseau Peercoin consommera moins d'énergie puisque la récompense de la preuve-de-travail sera moins intéressante et que les blocs seront générés à la place par la preuve-de-part.</p>
+				        <p>La preuve-de-part de débarrasse aussi de \"l'impôt\" d'environ un milliard de dollars du réseau Bitcoin avec sa preuve-de-travail. Vous pouvez en savoir plus à ce sujet en lisant <a href='http://letstalkbitcoin.com/is-bitcoin-overpaying-for-false-security/'>ceci</a>.</p>";
+$locale_strings['es']['faq_q_desc_efficiency'] = "
+						<p>La generación de bloques mediante proof-of-stake requiere mucha menos energía que generar hashes con hardware especializado mediante el proof-of-work. Esto significa que con el tiempo, la red Peercoin consumirá mucha menos energía a medida que los bloques generados mediante proof-of-work salgan menos a cuenta que los bloques generados mediante la porción del algoritmo del proof-of-stake.</p>
+				        <p>Además el Proof-of-stake se deshace del 'impuesto de ~$1000 millones de la red Bitcoin mediante los bloques proof-of-work. Puedes leer más acerca de esto <a href='http://letstalkbitcoin.com/is-bitcoin-overpaying-for-false-security/'>aquí</a>.</p>";
+$locale_strings['gr']['faq_q_desc_efficiency'] = "
+						<p>Η παραγωγή block απόδειξης-της-συμμετοχής απαιτεί πολύ λιγότερη ενέργεια από την παραγωγή εντατικού υλικού proof-of-work hashes. Αυτό σημαίνει ότι με το πέρασμα του χρόνου, το δίκτυο του Peercoin θα καταναλώνει λιγότερη ενέργεια όσο τα blocks απόδειξης-της-δουλειάς γίνονται λιγότερο ικανοποιητικά, και έτσι, αντί αυτού, blocks παράγονται από το τμήμα του αλγορίθμου που συμπεριλαμβάνει την απόδειξη-της-συμμετοχής.</p>
+				        <p>Η απόδειξη-της-συμμετοχής επίσης ξεφεύγει από το ~$1 δισεκατομμύριο 'φόρο' στο δίκτυο του Bitcoin μέσω των block απόδειξης-της-δουλειάς. Μπορείτε να διαβάσετε περισσότερα για αυτό <a href='http://letstalkbitcoin.com/is-bitcoin-overpaying-for-false-security/'>εδώ</a>.</p>";
+$locale_strings['cat']['faq_q_desc_efficiency'] = "
+						<p>La generació de blocs mitjançant proof-of-stake requereix molta menys energia que generar hashes amb hardware especialitzat mitjançant el proof-of-work. Això significa que amb el temps, la xarxa Peercoin consumirà molta menys energia a mesura que els blocs generats mitjançant proof-of-work siguin menys rentables que els blocs generats mitjançant la porció de l'algoritme del proof-of-stake.</p>
+				        <p>Ademés el Proof-of-stake es desfà de l'\"impost\" de ~$1000 milions de la xarxa Bitcoin mitjançant els blocs proof-of-work. Pots llegir més sobre això <a href='http://letstalkbitcoin.com/is-bitcoin-overpaying-for-false-security/'>aquí</a>.</p>";
+$locale_strings['zh']['faq_q_desc_efficiency'] = "
+						<p>通过股权证明产生区块耗能少.在长远上，当挖矿效益低时，大部分的区块将会是证明型股权区块，这将是非常环保的.</p>
+				        <p>股权证明还可以防止出现比特币一样的十亿美元税金事件.你可以从<a href='http://letstalkbitcoin.com/is-bitcoin-overpaying-for-false-security/'>这里</a>了解更多信息.</p>";
+
 $locale_strings['en']['faq_q_title_myth1'] = "Myth #1 - Peercoin is just a clone of Bitcoin.";
+$locale_strings['fr']['faq_q_title_myth1'] = "Mythe #1 - Peercoin est juste un clone de Bitcoin.";
+$locale_strings['es']['faq_q_title_myth1'] = "Mito #1 - Peercoin es sólo un clon de Bitcoin.";
+$locale_strings['gr']['faq_q_title_myth1'] = "Μύθος #1 - Το Peercoin είναι απλά ένας κλόνος του Bitcoin.";
+$locale_strings['cat']['faq_q_title_myth1'] = "Mite #1 - Peercoin és només un clon de Bitcoin.";
+$locale_strings['zh']['faq_q_title_myth1'] = "流言 #1 - 点点币只是比特币的一个克隆.";
+
 $locale_strings['en']['faq_q_desc_myth1'] = "
 						<p>Peercoin is one of the truly unique coins that are not just a clone of the original Bitcoin code.
 				           Peercoin is the first coin to introduce a proof-of-stake/proof-of-work combination along with other energy efficient mechanisms. In fact, many altcoins are now integrating Peercoin's proof-of-stake into their codebase.
 				           <br/> <br/>
 						   Source: <a href='http://en.wikipedia.org/wiki/PPCoin#Distinguishing_features'>http://en.wikipedia.org/wiki/PPCoin#Distinguishing_features</a>
 						</p>";
-$locale_strings['en']['faq_q_title_myth2'] = "Myth #2 - Peercoin is a centralized coin because of checkpointing.";
-$locale_strings['en']['faq_q_desc_myth2'] = "
-						<p>Checkpoints are an additional security measure and were introduced to protect the Peercoin network from attacks when it was in its infancy. Sunny King explains:</p>
-						<p>&quot;The risk of 51% denial-of-service attack on block chain is real, especially to a smaller network. In fact I wouldn’t exclude such a possibility to even bitcoin. Of course such an attack on bitcoin would likely not come from an individual due to the resource required. But it’s irresponsible to say that’s not possible. Just imagine what would happen if bitcoin stops processing transactions for a few days.&quot;</p>
-						<p>As Peercoin's network has grown substantially in the past year, checkpoints will be phased out in one of the next versions, probably in PPC 0.5.</p>";
-$locale_strings['en']['faq_q_title_myth3'] = "Myth #3 - Peercoin is extremely inflationary in nature.";
-$locale_strings['en']['faq_q_desc_myth3'] = "
-						<p>Nope. If Peercoin grows rapidly, stake minting may temporarily decrease as coin days are lost when trading. This would cause Peercoin to become deflationary. The flat nature of the transaction fees is intended to counter this by decreasing total transaction volume. Proponents of Peercoin argue that this will decrease deflation.</p>
-						<p>Furthermore, Bitcoin currently experiences <a href='http://letstalkbitcoin.com/is-bitcoin-overpaying-for-false-security/'>a ~10%</a> inflation per year as it approaches its total supply of 21 million. It is <b>hoped</b> that when the total supply is reached that the transactions fees will be enough to sustain a secure network.</p>
-						<p>To maintain a secure network in the future, Peercoin has a 1% a year inflation (proof-of-stake reward) to make sure there will be a secure network, no matter the transaction fees. As stated before this may become deflationary, as Bitcoin aims to be, during high volumes of transactions.</p>";
-
-$locale_strings['en']['convinced_you_header'] = "Convinced <b>you</b>?";
-$locale_strings['en']['convinced_you_desc'] = "Time to download the client, and try it yourself. If you have any questions just ask on the <a href='http://www.peercointalk.org/'>forum</a>, or the social links below.";
-
-$locale_strings['en']['tutorials'] = "Tutorials";
-$locale_strings['en']['installing_wallet'] = "Installing a Wallet";
-$locale_strings['en']['setting_up_wallet'] = "Setting Up Wallet";
-$locale_strings['en']['more_ellipsis'] = "More...";
-$locale_strings['en']['links'] = "Links";
-$locale_strings['en']['tools'] = "Tools";
-$locale_strings['en']['exchanges'] = "Exchanges";
-$locale_strings['en']['mining'] = "Mining";
-
-
-
-$locale_strings['fr']['languages'] = "Langues: ";
-$locale_strings['fr']['download_wallet'] = "Télécharger le Portefeuille";
-$locale_strings['fr']['price'] = "Prix";
-$locale_strings['fr']['market_cap'] = "Masse monétaire";
-$locale_strings['fr']['total_supply'] = "Quantité totale";
-$locale_strings['fr']['big_welcome_header'] = "Sûr. Durable. <span><strong>Peercoin</strong> est ici.</span>";
-$locale_strings['fr']['ticker_last_updated'] = "Dernière mise à jour: ";
-$locale_strings['fr']['ticker_last_updated_never'] = "jamais";
-
-$locale_strings['fr']['why_peercoin_header_innovation'] = "<b>Innovation</b> originale";
-$locale_strings['fr']['why_peercoin_desc_innovation'] = "L'innovation originale de Peercoin est le système <a href='/bin/peercoin-paper-fr.pdf'>hybride preuve-de-part/preuve-de-travail</a>. Comme d'autres <a href='https://fr.wikipedia.org/wiki/Crypto-monnaie'>crypto-monnaies</a>, la monnaie initiale peut être générée par extraction (minage), mais le coeur du réseau est maintenu par les possesseurs de monnaie, plutôt que par la <a href='https://en.bitcoin.it/wiki/Pooled_mining'>coopérative de mineurs</a> la plus rapide.";
-$locale_strings['fr']['why_peercoin_header_security'] = "<b>Sécurité</b> accrue";
-$locale_strings['fr']['why_peercoin_desc_security'] = "Maintenir le réseau avec l'algorithme hybride preuve-de-part/preuve-de-travail réduit les risques d'<a href='http://www.pcworld.com/article/2060840/selfish-miner-attack-could-devastate-bitcoin-researchers-say.html'> attaque par mineur égoïste</a>, d'<a href='https://en.bitcoin.it/wiki/Weaknesses'>attaque des 51%</a>, et de congestion de bloc qui ont été utilisées pour exploiter les autres crypto-monnaies.";
-$locale_strings['fr']['why_peercoin_header_efficiency'] = "<b>Efficacité</b> en terme d'énergie et de coût";
-$locale_strings['fr']['why_peercoin_desc_efficiency'] = "Maintenir le réseau demande bien moins d'énergie que la génération intensive de preuves-de-travail (hachages). La preuve-de-part se débarrasse également de <a href='http://letstalkbitcoin.com/is-bitcoin-overpaying-for-false-security/'>\"l'impôt\" d'un milliard de dollars</a> du réseau Bitcoin avec sa preuve-de-travail.";
-$locale_strings['fr']['why_peercoin_button'] = "Pourquoi Peercoin?";
-$locale_strings['fr']['why_peercoin_title'] = "Pourquoi <span>Peercoin</span>?";
-$locale_strings['fr']['why_peercoin_desc'] = "Grâce à un algorithme innovant de création de monnaie, le réseau Peercoin consomme bien moins d'énergie, maintient une meilleure sécurité, et récompense les utilisateurs d'une manière plus durable que les autres crypto-monnaies.";
-
-$locale_strings['fr']['fund_peercoin'] = "Financer <span>Peercoin.</span>";
-$locale_strings['fr']['fund_peercoin_accepting_donations'] = "Nous acceptons maintenant les dons pour le développement de Peercoin et du site web.";
-$locale_strings['fr']['fund_peercoin_donations_btc'] = "Dons en BTC: ";
-$locale_strings['fr']['fund_peercoin_donations_ppc'] = "Dons en PPC: ";
-$locale_strings['fr']['block_explorer'] = "Explorateur de blocs";
-
-$locale_strings['fr']['faq_header'] = "<span>Questions</span> fréquemment posées";
-$locale_strings['fr']['faq_q_title_innovation'] = "Dites m'en plus à propos de l'Innovation originale.";
-$locale_strings['fr']['faq_q_desc_innovation'] = "
-						<p>L'innovation originale notable de Peercoin est le système hybride preuve-de-part/preuve-de-travail.</p>
-						<p>Comme d'autres crypto-monnaies, la monnaie initiale peut être extraite par le processus communément utilisé de preuve-de-travail par hachage. Cependant contrairement aux autres monnaies, quand la difficulté d'extraction augmente avec le temps, les utilisateurs continuent à être récompensés avec la monnaie générée par l'algorithme additionnel de preuve-de-part. Une personne détenant 1% de la monnaie sera récompensée par 1% de la monnaie générée par les bloc preuve-de-part.</p>
-						<p>De plus, afin d'accroître la sécurité et l'efficacité énergétique, l'algorithme hybride preuve-de-part/preuve-de-travail combat les tendances déflationnistes dont souffrent les crypto-monnaies ayant une masse monétaire maximale fixée.</p>";
-$locale_strings['fr']['faq_q_title_security'] = "Dites m'en plus à propos de la Sécuritée accrue.";
-$locale_strings['fr']['faq_q_desc_security'] = "
-						<p>Générer les blocs par l'algorithme hybride preuve-de-part/preuve-de-travail réduit les risques d'attaque par mineur égoïste, d'attaque \">50%\", et de congéstion de bloc qui ont été utilisées pour exploiter les autres crypto-monnaies.</p>
-						<p>La portion preuve-de-part de l'algorithme est au coeur de cette sécurité car elle augmente drastiquement le coût d'une attaque. Acquerir 51% de toute la monnaie requiert plus d'efforts et de ressources qu'acquerir 51% de toute la puissance d'extraction. De plus, dans une attaque de part \">50%\", par définition l'attaquant a un fort risque de perdre son investissement, puisqu'il détient la majorité de la monnaie qu'il attaque. Ce risque de perte réduit la motivation à tenter une telle attaque en premier lieu.</p>
-						<p>Peercoin utilise aussi d'autres techniques pour la sécurité, comme les frais de transaction fixés au niveau du protocole pour se défendre contre les attaques par congéstion de bloc.</p>";
-$locale_strings['fr']['faq_q_title_efficiency'] = "Dites m'en plus à propos de l'Efficacité en terme d'énergie et de coût.";
-$locale_strings['fr']['faq_q_desc_efficiency'] = "
-						<p>Générer des blocs par preuve-de-part nécessite bien moins d'énergie que par la génération intensive de hachages pour la preuve-de-travail. Ceci signifie qu'à long terme, le réseau Peercoin consommera moins d'énergie puisque la récompense de la preuve-de-travail sera moins intéressante et que les blocs seront générés à la place par la preuve-de-part.</p>
-				        <p>La preuve-de-part de débarrasse aussi de \"l'impôt\" d'environ un milliard de dollars du réseau Bitcoin avec sa preuve-de-travail. Vous pouvez en savoir plus à ce sujet en lisant <a href='http://letstalkbitcoin.com/is-bitcoin-overpaying-for-false-security/'>ceci</a>.</p>";
-$locale_strings['fr']['faq_q_title_myth1'] = "Mythe #1 - Peercoin est juste un clone de Bitcoin.";
 $locale_strings['fr']['faq_q_desc_myth1'] = "
 						<p>Peercoin est l'une des monnaies vraiment uniques qui ne sont pas juste un clone du code original de Bitcoin.
 				           Peercoin est la première monnaie à introduire une combinaison preuve-de-part/preuve-de-travail ainsi que d'autres mécanismes d'efficacité énergétique. En fait, de nombreuses autres crypto-monnaies alternatives intègrent maintenant la preuve-de-part de Peercoin dans leur code de base.
 				           <br/> <br/>
 						   Source: <a href='http://en.wikipedia.org/wiki/PPCoin#Distinguishing_features'>http://en.wikipedia.org/wiki/PPCoin#Distinguishing_features</a>
 						</p>";
-$locale_strings['fr']['faq_q_title_myth2'] = "Mythe #2 - Peercoin est une monnaie centralisée à cause des points de contrôle.";
-$locale_strings['fr']['faq_q_desc_myth2'] = "
-						<p>Les points de contrôle sont une mesure de sécurité supplémentaire qui ont été introduits pour protéger le réseau Peercoin des attaques quand il était dans son enfance. Sunny King explique:</p>
-						<p>&quot;Le risque d'une attaque des 51% par déni-de-service sur la chaîne de blocs est réel, surtout pour un petit réseau. En fait je n'exclurait pas une telle possibilité même pour Bitcoin. Bien sûr une telle attaque sur Bitcoin ne viendrait probablement pas d'un unique individu à cause des ressources requises. Mais il est irresponsable de dire que ce n'est pas possible. Imaginez juste ce qui se passerait si Bitcoin arrêtait de traiter les transactions pendant quelques jours.&quot;</p>
-						<p>Puisque le réseau Peercoin a grandi substantiellement dans l'année passée, les points de contrôle seront supprimés dans l'une des versions à venir, probablement dans PPC 0.5.</p>";
-$locale_strings['fr']['faq_q_title_myth3'] = "Mythe #3 - Peercoin est extrèmement inflationniste par nature.";
-$locale_strings['fr']['faq_q_desc_myth3'] = "
-						<p>Non. Si Peercoin grandit rapidement, la génération de monnaie par preuve-de-part peut diminuer temporairement car des jours-pièces sont perdus dans les échanges. Ceci rendrait Peercoin déflationniste. Les frais de transaction fixes sont prévus pour contrer ceci en reduisant le volume total de transactions. Les promoteurs de Peercoin considèrent que cela réduira la déflation.</p>
-						<p>De plus, Bitcoin connaît actuellement une inflation <a href='http://letstalkbitcoin.com/is-bitcoin-overpaying-for-false-security/'>d'environ 10%</a> par an alors qu'il approche de sa masse monétaire totale de 21 millions. Les gens <b>espèrent</b> que lorsque la masse monétaire maximale sera atteinte, les frais de transaction seront suffisants pour maintenir la sécurité du réseau.</p>
-						<p>Pour maintenir la sécurité du réseau dans le futur, Peercoin a une inflation annuelle de 1% (récompense de preuve-de-part) afin de s'assurer un réseau sûr, quels que soient les frais de transaction. Comme indiqué précedemment ceci pourrait rendre Peercoin déflationniste, comme Bitcoin vise à l'être, pendant les hauts volumes de transactions.</p>";
-
-$locale_strings['fr']['convinced_you_header'] = "<b>Convaincu</b>?";
-$locale_strings['fr']['convinced_you_desc'] = "Il est temps de télécharger le client, et de l'essayer par vous-même. Si vous avez des questions, posez les sur le <a href='http://www.peercointalk.org/'>forum</a>, ou sur les réseaux sociaux ci-dessous.";
-
-$locale_strings['fr']['tutorials'] = "Tutoriels";
-$locale_strings['fr']['installing_wallet'] = "Installer le Portefeuille";
-$locale_strings['fr']['setting_up_wallet'] = "Configurer le Portefeuille";
-$locale_strings['fr']['more_ellipsis'] = "Plus...";
-$locale_strings['fr']['links'] = "Liens";
-$locale_strings['fr']['tools'] = "Outils";
-$locale_strings['fr']['exchanges'] = "Échanges";
-$locale_strings['fr']['mining'] = "Extraction";
-
-
-$locale_strings['es']['languages'] = "Idiomas: ";
-$locale_strings['es']['download_wallet'] = "Descargar Monedero";
-$locale_strings['es']['price'] = "Precio";
-$locale_strings['es']['market_cap'] = "Capitalización total";
-$locale_strings['es']['total_supply'] = "Suministro total";
-$locale_strings['es']['big_welcome_header'] = "Seguro. Sostenible. <span><strong>Peercoin</strong> está aquí.</span>";
-$locale_strings['es']['ticker_last_updated'] = "Última actualización: ";
-$locale_strings['es']['ticker_last_updated_never'] = "nunca";
-
-$locale_strings['es']['why_peercoin_header_innovation'] = "<b>Innovación</b> original";
-$locale_strings['es']['why_peercoin_desc_innovation'] = "La innovación original de Peercoin es el sistema <a href='/bin/peercoin-paper-es.pdf'>híbrido proof-of-stake/proof-of-work</a>. Como en otras <a href='https://en.wikipedia.org/wiki/Cryptocurrency'>criptomonedas</a>, las monedas iniciales pueden ser minadas, pero la red principal está mantenida por los propietarios de monedas, en lugar de los <a href='https://en.bitcoin.it/wiki/Pooled_mining'>pools</a> más rápidos.";
-$locale_strings['es']['why_peercoin_header_security'] = "Más <b>Seguro</b>";
-$locale_strings['es']['why_peercoin_desc_security'] = "Manteniendo la red a través del algoritmo híbrido proof-of-work/proof-of-stake, se reduce el riesgo de aprovechamiento del <a href='http://www.pcworld.com/article/2060840/selfish-miner-attack-could-devastate-bitcoin-researchers-say.html'> defecto de Minero Egoísta</a>, los <a href='https://en.bitcoin.it/wiki/Weaknesses'>ataques del 51%</a>, y el hinchado de monedas que se ha usado para atacar a otras monedas.";
-$locale_strings['es']['why_peercoin_header_efficiency'] = "<b>Eficiencia</b> y reducción del coste energético";
-$locale_strings['es']['why_peercoin_desc_efficiency'] = "El mantenimiento de la red requiere mucha menos energía que la generación de hashes proof-of-work mediante hardware especializado. El Proof-of-stake también se deshace del <a href='http://letstalkbitcoin.com/is-bitcoin-overpaying-for-false-security/'> \"impuesto\"de ~$1000 millones </a> de la red Bitcoin mediante bloques proof-of-work.";
-$locale_strings['es']['why_peercoin_button'] = "¿Por qué Peercoin?";
-$locale_strings['es']['why_peercoin_title'] = "¿Por qué <span>Peercoin</span>?";
-$locale_strings['es']['why_peercoin_desc'] = "Mediante un innovativo algoritmo de acuñado, la red Peercoin consume mucha menos energía, tiene una seguridad más fuerte, y recompensa a sus usuarios de una manera más sostenible que otras criptomonedas.";
-
-$locale_strings['es']['fund_peercoin'] = "Financia <span>Peercoin.</span>";
-$locale_strings['es']['fund_peercoin_accepting_donations'] = " Aceptamos donaciones para el desarrollo de Peercoin y la página web.";
-$locale_strings['es']['fund_peercoin_donations_btc'] = "Donaciones con BTC: ";
-$locale_strings['es']['fund_peercoin_donations_ppc'] = "Donaciones con PPC: ";
-$locale_strings['es']['block_explorer'] = "Explorador de bloques";
-
-$locale_strings['es']['faq_header'] = "<span>Preguntas</span> frecuentes";
-$locale_strings['es']['faq_q_title_innovation'] = "Cuéntame más acerca de la Innovación Original.";
-$locale_strings['es']['faq_q_desc_innovation'] = "
-						<p>La más notoria innovación original de Peercoin es el sistema híbrido proof-of-stake/proof-of-work.</p>
-						<p>Como otras criptomonedas, las monedas iniciales pueden ser minadas con el sistema tradicional de procesado de hashing mediante el proof-of-work. Sin embargo, a diferencia de otras monedas, mientras la dificultad de hashing aumenta con el tiempo, los usuarios continúan siendo recompensados con monedas generadas con el algoritmo adicional del proof-of-stake. Cualquiera que tenga moneda, será recompensado con un 1% del total mediante bloques proof-of-stake.</p>
-						<p>Adicionalmente al aumento de seguridad in la mejorada eficiencia energética, el sistema híbrido del algoritmo proof-of-work/proof-of-stake combate las tendencias deflacionarias que las criptomonedas pueden sufrir debido a su tope de acuñado preestablecido.</p>";
-$locale_strings['es']['faq_q_title_security'] = "Cuéntame más acerca de la Seguridad Mejorada.";
-$locale_strings['es']['faq_q_desc_security'] = "
-						<p>La generación de bloques mediante el algoritmo híbrido proof-of-work/proof-of-stake reduce el riesgo del defecto del Minero Egoísta de Cornell, ataques de\">50%\", y el hinchado de bloques que se ha usado para aprovecharse de otras monedas.</p>
-						<p>La porción proof-of-stake del algoritmo está en el corazón de las medidas de seguridad porque aumenta considerablemente el coste de un ataque. Adquirir el 51% de todas las monedas existentes requiere más esfuerzo y recursos que adquirir el 51% de todo el poder de minado. Además, en un ataque stake de \">50%\", la inversión del atacante será, por definición, un gran riesgo de pérdida, porque el atacante tendrá la mayoría de monedas que está atacando. Este riesgo de pérdida reduce el incentivo de intentar ese tipo de ataque en primer lugar.</p>
-						<p>Peercoin también emplea otras medidas de seguridadad avanzadas, como forzar tasas de transacción a nivel de protocolo para defenderse de ataques de hinchado de monedas.</p>";
-$locale_strings['es']['faq_q_title_efficiency'] = "Cuéntame más acerca de la eficiencia energética.";
-$locale_strings['es']['faq_q_desc_efficiency'] = "
-						<p>La generación de bloques mediante proof-of-stake requiere mucha menos energía que generar hashes con hardware especializado mediante el proof-of-work. Esto significa que con el tiempo, la red Peercoin consumirá mucha menos energía a medida que los bloques generados mediante proof-of-work salgan menos a cuenta que los bloques generados mediante la porción del algoritmo del proof-of-stake.</p>
-				        <p>Además el Proof-of-stake se deshace del 'impuesto de ~$1000 millones de la red Bitcoin mediante los bloques proof-of-work. Puedes leer más acerca de esto <a href='http://letstalkbitcoin.com/is-bitcoin-overpaying-for-false-security/'>aquí</a>.</p>";
-$locale_strings['es']['faq_q_title_myth1'] = "Mito #1 - Peercoin es sólo un clon de Bitcoin.";
 $locale_strings['es']['faq_q_desc_myth1'] = "
 						<p>Peercoin es una de las pocas monedas únicas que no son sólo un clon del código de Bitcoin.
 				           Peercoin es la primera moneda en introducir una combinación de proof-of-stake/proof-of-work junto con otros mecanismos energéticamente eficientes. De hecho, muchas monedas alternativas están integrando hoy en día en sus códigos el proof-of-stake de Peercoin.
 				           <br/> <br/>
 						   Fuente: <a href='http://en.wikipedia.org/wiki/PPCoin#Distinguishing_features'>http://en.wikipedia.org/wiki/PPCoin#Distinguishing_features</a>
 						</p>";
-$locale_strings['es']['faq_q_title_myth2'] = "Mito #2 - Peercoin es una moneda centralizada debido a los puntos de control.";
-$locale_strings['es']['faq_q_desc_myth2'] = "
-						<p>Los puntos de control centralizados son una medida de seguridad adicional y fueron introducidos para proteger la red Peercoin de ataques mientras la red está en su infancia. Sunny King lo explica:</p>
-						<p>&quot;El riesgo de un ataque de denegación de servicio del 51% en la cadena de bloques es real, especialmente en una red pequeña. De hecho, no excluyo esta posibilidad incluso en la red Bitcoin. Por supuesto tal ataque a Bitcoin no vendría de una persona individual debido a la cantidad de recursos necesarios para llevar a cabo tal ataque. Pero sería irresponsable decir que no es una posibilidad real. Tan sólo hace falta imaginar qué pasaría si la red dejara de procesar transacciones por unos pocos días.&quot;</p>
-						<p>Ya que la red Peercoin ha crecido sustancialmente durante el pasado año, los puntos de control se eliminarán gradualmente en una de las próximas versiones de Peercoin, probablemente la 0.5.</p>";
-$locale_strings['es']['faq_q_title_myth3'] = "Mito #3 - Peercoin tiene una naturaleza extremadamente inflacionara.";
-$locale_strings['es']['faq_q_desc_myth3'] = "
-						<p>No. Si Peercoin crece rápidamente, el acuñado mediante Stake se reducirá temporalmente mientras los días de moneda se pierden debido al comercio de éstas. Esto causaría que Peercoin fuera deflacionarioy. La naturaleza de las tasas de transacción fijadas se diseñaron como medida de contrarestar esto, reduciendo el volumen de total de transacciones. Los defensores de Peercoin argumentan que esto disminuirá la deflación.</p>
-						<p>Además, Bitcoin experimenta actualmente <a href='http://letstalkbitcoin.com/is-bitcoin-overpaying-for-false-security/'>un ~10%</a> de inflación anual mientras de acerca a su suministro total de 21 millones de monedas. Se <b>espera</b> que cuando se alcance el suministro total de monedas las tasas de transacción serán suficientes para mantener una red segura.</p>
-						<p>Para mantener una red segura en el futuro, Peercoin provee una inflación anual del 1% (recompensa por proof-of-stake) para asegurarse que habrá una red segura, independientemente de las tasas de transacción. Como se ha comentado antes, esto volverá la moneda deflacionaria, igual que Bitcoin pretende ser, durante niveles de transacciones altos.</p>";
-
-$locale_strings['es']['convinced_you_header'] = "¿<b>Convencido</b>?";
-$locale_strings['es']['convinced_you_desc'] = "Es hora de descargar el cliente y probarlo tú mismo. Si tienes alguna duda simplemente pregunta en el <a href='http://www.peercointalk.org/'>foro</a>, o los enlaces a redes sociales de más abajo.";
-
-$locale_strings['es']['tutorials'] = "Tutoriales";
-$locale_strings['es']['installing_wallet'] = "Instalar monedero";
-$locale_strings['es']['setting_up_wallet'] = "Configurar monedero";
-$locale_strings['es']['more_ellipsis'] = "Más...";
-$locale_strings['es']['links'] = "Enlaces";
-$locale_strings['es']['tools'] = "Herramientas";
-$locale_strings['es']['exchanges'] = "Exchanges";
-$locale_strings['es']['mining'] = "Minado";
-
-
-
-
-$locale_strings['gr']['languages'] = "Γλώσσες: ";
-$locale_strings['gr']['download_wallet'] = "Κατέβασε το Πορτοφόλι";
-$locale_strings['gr']['price'] = "Τιμή";
-$locale_strings['gr']['market_cap'] = "Κεφαλαιοποίηση";
-$locale_strings['gr']['total_supply'] = "Συνολική Προσφορά";
-$locale_strings['gr']['big_welcome_header'] = "Ασφαλές. Ανεκτό. Το <span><strong>Peercoin</strong> είναι εδώ.</span>";
-$locale_strings['gr']['ticker_last_updated'] = "Τελευταία ενημέρωση: ";
-$locale_strings['gr']['ticker_last_updated_never'] = "ποτέ";
-
-$locale_strings['gr']['why_peercoin_header_innovation'] = "Πρωτότυπη <b>Καινοτομία</b>";
-$locale_strings['gr']['why_peercoin_desc_innovation'] = "Η πρωτότυπη καινοτομία του Peercoin είναι το σύστημα του <a href='/bin/peercoin-paper.pdf'>υβρίδιου απόδειξης-της-συμμετοχής/απόδειξης-της-δουλειάς</a>. Όπως άλλα <a href='https://en.wikipedia.org/wiki/Cryptocurrency'>κρυπτονομίσματα</a>, τα αρχικά νομίσματα μπορούν να εξορυχθούν, αλλά ο πυρήνας του δικτύου διαχειρίζεται από τους κάτοχους των κερμάτων, αντί του γρηγορότερoυ <a href='https://en.bitcoin.it/wiki/Pooled_mining'>κοινού ταμείου</a>.";
-$locale_strings['gr']['why_peercoin_header_security'] = "Αυξημένη <b>Ασφάλεια</b>";
-$locale_strings['gr']['why_peercoin_desc_security'] = "Η διαχείρηση του δικτύου μέσω του αλγορίθμου απόδειξης-της-δουλειάς/απόδειξης-της-συμμετοχής μειώνει τον κίνδυνο του <a href='http://www.pcworld.com/article/2060840/selfish-miner-attack-could-devastate-bitcoin-researchers-say.html'>Ελλατώματος του Εγωιστή-Μεταλλωρύχου</a>, <a href='https://en.bitcoin.it/wiki/Weaknesses'>το 51% των επιθέσεων</a>, και το block bloating που έχει χρησιμοποιηθεί για την εκμετάλλευση άλλων νομισμάτων.";
-$locale_strings['gr']['why_peercoin_header_efficiency'] = "Ενεργειακή και Χρηματική <b>Απόδοση</b>";
-$locale_strings['gr']['why_peercoin_desc_efficiency'] = "Η διαχείριση του δικτύου απαιτεί πολύ λιγότερη ενέργεια από την παραγωγή εντατικού υλικού proof-of-work hashes. Η απόδειξη-της-συμμετοχής επίσης ξεφεύγει από το <a href='http://letstalkbitcoin.com/is-bitcoin-overpaying-for-false-security/'> ~$1 δισεκατομμύριο \"φόρο\"</a> του δίκτυου του Bitcoin μέσω των block απόδειξης-της-δουλειάς.";
-$locale_strings['gr']['why_peercoin_button'] = "Γιατί Peercoin;";
-$locale_strings['gr']['why_peercoin_title'] = "Γιατί <span>Peercoin</span>;";
-$locale_strings['gr']['why_peercoin_desc'] = "Μέσω ενός καινοτόμου αλγορίθμου κοπής νομισμάτων, το δίκτυο του Peercoin καταναλώνει πολύ λιγότερη ενέργεια, διατηρεί υψηλότερη ασφάλεια, και ανταμοίβει του χρήστες με πιο ανεκτούς τρόπους από άλλα κρυπτονομίσματα.";
-
-$locale_strings['gr']['fund_peercoin'] = "Χρηματοδοτήστε το <span>Peercoin.</span>";
-$locale_strings['gr']['fund_peercoin_accepting_donations'] = "Τώρα δεχόμαστε δωρεές μέσω της Ανάπτυξης του Peercoin και της Διαδικτυακής Χρηματοδότησης.";
-$locale_strings['gr']['fund_peercoin_donations_btc'] = "BTC Δωρεές: ";
-$locale_strings['gr']['fund_peercoin_donations_ppc'] = "PPC Δωρεές: ";
-$locale_strings['gr']['block_explorer'] = "Εξερευνητής Block";
-
-$locale_strings['gr']['faq_header'] = "Συχνά <span>ερωτήματα</span>";
-$locale_strings['gr']['faq_q_title_innovation'] = "Πείτε μου περισσότερα για την Πρωτότυπη Καινοτομία.";
-$locale_strings['gr']['faq_q_desc_innovation'] = "
-						<p>Η πρωτότυπη και αξιοσημείωτη καινοτομία του Peercoin είναι το σύστημα του υβριδίου της απόδειξης-της-συμμετοχής/απόδειξης-της-δουλειάς.</p>
-						<p>Όπως και άλλα κρυπτονομίσματα, τα αρχικά νομίσματα μπορούν να εξορυχθούν μέσω των κοινών απόδειξης-της-δουλειάς hashing διαδικασιών. Παρ'όλα αυτά, σε αντίθεση με τα άλλα νομίσματα, όσο η δυσκολία hashing μεγαλώνει καθώς περνάει ο χρόνος, οι χρήστες συνεχίζουν να ανταμείβονται με νομίσματα τα οποία παράγονται από τον επιπλέον αλγόριθμο της απόδειξης-της-συμμετοχής. Οποιοσδήποτε έχει το 1% του νομίσματος θα αποζημιώνεται με το 1% από όλων των blocks της απόδειξης-της-συμμετοχής.</p>
-						<p>Επιπροσθέτως της αυξανόμενης ασφάλειας και της βελτιωμένης ενεργειακής απόδοσης, ο υβριδικός αλγόριθμος απόδειξης-της-δουλειάς/απόδειξης-της-συμμετοχής καταπολεμά τις αποπληθωριστικές τάσεις από τις οποίες μπορούν να υποφέρουν τα κρυπτονομίσματα λόγω των σκληρών καλυμμάτων νομισματοκοπίας.</p>";
-$locale_strings['gr']['faq_q_title_security'] = "Πείτε μου περισσότερα για την Αυξημένη Ασφάλεια.";
-$locale_strings['gr']['faq_q_desc_security'] = "
-						<p>Η παραγωγή blocks μέσω του υβριδικού αλγορίθμου απόδειξης-της-συμμετοχής μειώνει τον κίνδυνο του Ελλατώματος του Εγωιστή-Μεταλλωρύχου του Cornell, \">50%\" των επιθέσεων, και το block bloating που έχει χρησιμοποιηθεί για την εκμετάλλευση άλλων νομισμάτων.</p>
-						<p>Το τμήμα του αλγορίθμου που αναφέρεται στην απόδειξη-της-συμμετοχής βρίσκεται στην καρδιά της ασφάλειας επειδή αυξάνει δραστικά το κόστος μιας επίθεσης. Η απόκτηση του 51% από όλα τα υπάρχοντα νομίσματα απαιτεί περισσότερη προσπάθεια και πόρους από όσο η απόκτηση του 51% όλης της δύναμης εξόρυξης. Επιπλέον, σε μία μετοχική επίθεση της τάξης του \">50%\", η επένδυση του εισβολέα θα είναι, εξ ορισμού, σε κίνδυνο τεράστιας απώλειας επειδή ο ίδιος θα έχει στα χέρια του την πλειονότητα των κερμάτων στα οποία επιτίθεται. Αυτός ο κίνδυνος απώλειας μειώνει το κίνητρο του να προσπαθήσει κάποιος μια τέτοια επίθεση εξαρχής.</p>
-						<p>Το Peercoin επίσης χρησιμοποιεί και άλλα προηγμένα χαρακτηριστικά ασφαλείας συμπεριλαμβανομένης της εφαρμογής των τελών συναλλαγής σε επίπεδο πρωτοκόλλου για την υπεράσπιση ενάντια στις block bloating επιθέσεις.</p>";
-$locale_strings['gr']['faq_q_title_efficiency'] = "Πείτε μου περισσότερα για την Αποδοτικότητα της Ενέργειας και του Κόστους.";
-$locale_strings['gr']['faq_q_desc_efficiency'] = "
-						<p>Η παραγωγή block απόδειξης-της-συμμετοχής απαιτεί πολύ λιγότερη ενέργεια από την παραγωγή εντατικού υλικού proof-of-work hashes. Αυτό σημαίνει ότι με το πέρασμα του χρόνου, το δίκτυο του Peercoin θα καταναλώνει λιγότερη ενέργεια όσο τα blocks απόδειξης-της-δουλειάς γίνονται λιγότερο ικανοποιητικά, και έτσι, αντί αυτού, blocks παράγονται από το τμήμα του αλγορίθμου που συμπεριλαμβάνει την απόδειξη-της-συμμετοχής.</p>
-				        <p>Η απόδειξη-της-συμμετοχής επίσης ξεφεύγει από το ~$1 δισεκατομμύριο 'φόρο' στο δίκτυο του Bitcoin μέσω των block απόδειξης-της-δουλειάς. Μπορείτε να διαβάσετε περισσότερα για αυτό <a href='http://letstalkbitcoin.com/is-bitcoin-overpaying-for-false-security/'>εδώ</a>.</p>";
-$locale_strings['gr']['faq_q_title_myth1'] = "Μύθος #1 - Το Peercoin είναι απλά ένας κλόνος του Bitcoin.";
 $locale_strings['gr']['faq_q_desc_myth1'] = "
 						<p>Το Peercoin είναι ένα από τα πραγματικά μοναδικά νομίσματα που δεν είναι απλά ένας κλόνος από τον πρωτότυπο κώδικα του Bitcoin.
 				           Το Peercoin είναι το πρώτο νόμισμα που εισαγάγει έναν συνδυασμό απόδειξης-της-συμμετοχής/απόδειξης-της-δουλειάς μαζί με άλλους ενεργειακά αποδοτικούς μηχανισμούς. Στην πραγματικότητα, πολλά altcoins τώρα ενσωματώνουν την απόδειξη-της-συμμετοχής του Peercoin μέσα στην βάση του κώδικά τους.
 				           <br/> <br/>
 						   Πηγή: <a href='http://en.wikipedia.org/wiki/PPCoin#Distinguishing_features'>http://en.wikipedia.org/wiki/PPCoin#Distinguishing_features</a>
 						</p>";
-$locale_strings['gr']['faq_q_title_myth2'] = "Μύθος #2 - Το Peercoin είναι ένα συγκεντρωτικό νόμισμα λόγω του checkpointing.";
-$locale_strings['gr']['faq_q_desc_myth2'] = "
-						<p>Τα checkpoints (σημεία ελέγχου) είναι επιπρόσθετα μέτρα ασφαλείας και είχαν εισαχθεί έτσι ώστε να προστατεύουν το δίκτυο του Peercoin από επιθέσεις όταν ακόμα ήταν στη νηπιακή του ηλικία. Ο Sunny King εξηγεί:</p>
-						<p>&quot;Ο κίνδυνος της 51% denial-of-service επίθεσης στην αλυσίδα block είναι αληθινός, ειδικά σε ένα μικρότερο δίκτυο. Στην πραγματικότητα δεν θα απέκλεια μια τέτοια πιθανότητα ούτε ακόμα και στο bitcoin. Φυσικά μία τέτοια επίθεση στο bitcoin πιθανότατα δεν θα ερχόταν από έναν άτομο λόγω των πόρων που χρειάζεται. Αλλά είναι ανεύθυνο να λέγεται ότι είναι απίθανο να συμβεί. Απλά φανταστείτε τι θα συνέβαινε εάν το bitcoin σταματούσε να επεξεργαζόταν συναλλαγές για μερικές μέρες.&quot;</p>
-						<p>Μιας και το δίκτυο του Peercoin έχει μεγαλώσει ουσιαστικά στον περασμένο χρόνο, τα σημεία ελέγχου σταδιακά θα καταργηθούν σε μία από τις επερχόμενες εκδόσεις, πιθανόν στο PPC 0.5.</p>";
-$locale_strings['gr']['faq_q_title_myth3'] = "Μύθος #3 - Το Peercoin είναι εξαιρετικά πληθωριστικό στη φύση.";
-$locale_strings['gr']['faq_q_desc_myth3'] = "
-						<p>Όχι. Εάν το Peercoin μεγαλώνει γρήγορα, η χρηματοδότηση της κοπής ίσως μειωθεί προσωρινά όσο μέρες νομίσματος θα χάνονται καθώς γίνονται διακινήσεις. Αυτό θα έκανε το Peercoin να γίνει αποπληθωριστικό. Η επίπεδη φύση των τελών συναλλαγής σκοπεύει να το αντιμετωπίσει αυτό με το να μειώσει το συνολικό όγκο συναλλαγών. Οι υποστηρικτές του Peercoin υποστηρίζουν ότι αυτό θα μειώσει τον αποπληθωρισμό.</p>
-						<p>Επιπροσθέτως, το Bitcoin αυτή τη στιγμή βιώνει <a href='http://letstalkbitcoin.com/is-bitcoin-overpaying-for-false-security/'>ένα ~10%</a> πληθωρισμό το χρόνο όσο πλησιάζει τη συνολική προσφορά των 21 εκατομμυρίων. <b>Ελπίζεται</b> ότι όταν φτάσει αυτό το ποσό τα κόστα συναλλαγής θα είναι αρκετά για την διατήρηση ενός ασφαλούς δικτύου.</p>
-						<p>Για τη διατήρηση ενός ασφαλούς δικτύου στο μέλλον, το Peercoin έχει 1% πληθωρισμό το χρόνο (ανταμοιβή της απόδειξης-της-συμμετοχής) για να διασφαλήσει ότι θα υπάρχει ένα ασφαλές δίκτυο, χωρίς να δίνει καμία σημασία στα τέλη συναλλαγών. Όπως προαναφέρθηκε αυτό μπορεί να γίνει αποπληθωριστικό, όπως στοχεύει και το Bitcoin να γίνει, κατά τη διάρκεια μεγάλου όγκου συναλλαγών.</p>";
-
-$locale_strings['gr']['convinced_you_header'] = "<b>Σε</b> πείσαμε;";
-$locale_strings['gr']['convinced_you_desc'] = "Ώρα να κατεβάσεις το πρόγραμμα, και να το δοκιμάσεις ο ίδιος. Εάν έχεις οποιαδήποτε ερώτηση απλά ρώτα στο <a href='http://www.peercointalk.org/'>φόρουμ</a>, ή στους σύνδεσμους κοινωνικών δίκτυων από κάτω.";
-
-$locale_strings['gr']['tutorials'] = "Οδηγοί";
-$locale_strings['gr']['installing_wallet'] = "Εγκατάσταση Πορτοφολιού";
-$locale_strings['gr']['setting_up_wallet'] = "Ρύθμιση Πορτοφολιού";
-$locale_strings['gr']['more_ellipsis'] = "Περισσότερα...";
-$locale_strings['gr']['links'] = "Σύνδεσμοι";
-$locale_strings['gr']['tools'] = "Εργαλεία";
-$locale_strings['gr']['exchanges'] = "Ανταλλαγές";
-$locale_strings['gr']['mining'] = "Εξόρυξη";
-
-
-
-
-$locale_strings['cat']['languages'] = "Idiomes: ";
-$locale_strings['cat']['download_wallet'] = "Descarregar Moneder";
-$locale_strings['cat']['price'] = "Preu";
-$locale_strings['cat']['market_cap'] = "Capitalització total";
-$locale_strings['cat']['total_supply'] = "Subministrament total";
-$locale_strings['cat']['big_welcome_header'] = "Segur. Sostenible. <span><strong>Peercoin</strong> és aquí.</span>";
-$locale_strings['cat']['ticker_last_updated'] = "Darrera actualització: ";
-$locale_strings['cat']['ticker_last_updated_never'] = "mai";
-
-$locale_strings['cat']['why_peercoin_header_innovation'] = "<b>Innovació</b> original";
-$locale_strings['cat']['why_peercoin_desc_innovation'] = "L'innovació original de Peercoin és el sistema <a href='/bin/peercoin-paper-es.pdf'>híbrid proof-of-stake/proof-of-work</a>. Com en d'altres <a href='https://en.wikipedia.org/wiki/Cryptocurrency'>criptomonedes</a>, les monedes inicials poden ser minades, però la xarxa principal és mantenida pels propietaris de monedes, en lloc dels <a href='https://en.bitcoin.it/wiki/Pooled_mining'>pools</a> més ràpids.";
-$locale_strings['cat']['why_peercoin_header_security'] = "Més <b>Segur</b>";
-$locale_strings['cat']['why_peercoin_desc_security'] = "Mantenint la xarxa a través de l'algoritme híbrid proof-of-work/proof-of-stake, es redueix el risc d'aprofitament del <a href='http://www.pcworld.com/article/2060840/selfish-miner-attack-could-devastate-bitcoin-researchers-say.html'> defecte del Miner Egoista</a>, els <a href='https://en.bitcoin.it/wiki/Weaknesses'>atacs del 51%</a>, i l'inflat de monedes que s'ha utilitzat per atacar a d'altres monedes.";
-$locale_strings['cat']['why_peercoin_header_efficiency'] = "<b>Eficiència</b> i reducció del cost energètic";
-$locale_strings['cat']['why_peercoin_desc_efficiency'] = "El manteniment de la xarxa requereix molta menys energia que la generació de hashes proof-of-work mitjançant hardware especialitzat. El Proof-of-stake també es desfà de <a href='http://letstalkbitcoin.com/is-bitcoin-overpaying-for-false-security/'> l'\"impost\"de ~$1000 milions </a> de la xarxa Bitcoin mitjançant els blocs proof-of-work.";
-$locale_strings['cat']['why_peercoin_button'] = "¿Per què Peercoin?";
-$locale_strings['cat']['why_peercoin_title'] = "¿Per què <span>Peercoin</span>?";
-$locale_strings['cat']['why_peercoin_desc'] = "Mitjançant un innovatiu algoritme d'encunyament, la xarxa Peercoin consumeix molta menys energia, té una seguretat més forta i recompensa els seus usuaris d'una forma més sostenible que altres criptomonedes.";
-
-$locale_strings['cat']['fund_peercoin'] = "Financia <span>Peercoin.</span>";
-$locale_strings['cat']['fund_peercoin_accepting_donations'] = " Aceptem donacions per al dessenvolupament de Peercoin i la plana web.";
-$locale_strings['cat']['fund_peercoin_donations_btc'] = "Donacions amb BTC: ";
-$locale_strings['cat']['fund_peercoin_donations_ppc'] = "Donacions amb PPC: ";
-$locale_strings['cat']['block_explorer'] = "Explorador de blocs";
-
-$locale_strings['cat']['faq_header'] = "<span>Preguntes</span> freqüents";
-$locale_strings['cat']['faq_q_title_innovation'] = "Explica'm més sobre l'Innovació Original.";
-$locale_strings['cat']['faq_q_desc_innovation'] = "
-						<p>La més notoria innovació original de Peercoin és el sistema híbrid proof-of-stake/proof-of-work.</p>
-						<p>Com d'altres criptomonedes, les monedes inicials poden ser minades amb el sistema tradicional de processat de hashing mitjançant el proof-of-work. No obstant, a diferència d'altres monedes, mentre la dificultat de hashing augmenta amb el temps, els usuaris continuen sent recompensats amb monedes generades amb l'algoritme adicional del proof-of-stake. Cualsevol que tingui moneda, serà recompensat amb un 1% del total mitjançant blocs proof-of-stake.</p>
-						<p>Adicionalment a l'augment de seguretat i la millorada eficiència energética, el sistema híbrid de l'algoritme proof-of-work/proof-of-stake combat les tendencies deflacionaries que les criptomonedes poden patir degut al seu límit d'encunyament preestablert.</p>";
-$locale_strings['cat']['faq_q_title_security'] = "Explica'm més sobre la Seguretat Millorada.";
-$locale_strings['cat']['faq_q_desc_security'] = "
-						<p>La generació de blocs mitjançant l'algoritme híbrid proof-of-work/proof-of-stake redueix el risc del defecte del Miner Egoísta de Cornell, atacs de\">50%\", i l'inflat de blocs que s'ha utilitzat per aprofitar-se d'altres monedes.</p>
-						<p>La porció proof-of-stake de l'algoritme és al cor de les mesures de seguretat perquè augmenta considerablement el cost d'un atac. Adquirir el 51% de totes les monedes existents requereix de més esforç i recursos que adquirir el 51% de tot el poder de minat. Ademés, en un atac stake de \">50%\", l'inversió de l'atacant serà, per definició, un gran risc de pèrdua, perque l'atacant tindrà la major part de les monedes que està atacant. Aquest risc de pèrdua redueix l'incentiu d'intentar aquest tipus d'atac en primer lloc.</p>
-						<p>Peercoin també fa servir altres mesures de seguretat avançades, com forçar tases de transacció a nivell de protocol per defendre's d'atacs d'inflat de monedes.</p>";
-$locale_strings['cat']['faq_q_title_efficiency'] = "Explica'm més sobre l'eficiència energética.";
-$locale_strings['cat']['faq_q_desc_efficiency'] = "
-						<p>La generació de blocs mitjançant proof-of-stake requereix molta menys energia que generar hashes amb hardware especialitzat mitjançant el proof-of-work. Això significa que amb el temps, la xarxa Peercoin consumirà molta menys energia a mesura que els blocs generats mitjançant proof-of-work siguin menys rentables que els blocs generats mitjançant la porció de l'algoritme del proof-of-stake.</p>
-				        <p>Ademés el Proof-of-stake es desfà de l'\"impost\" de ~$1000 milions de la xarxa Bitcoin mitjançant els blocs proof-of-work. Pots llegir més sobre això <a href='http://letstalkbitcoin.com/is-bitcoin-overpaying-for-false-security/'>aquí</a>.</p>";
-$locale_strings['cat']['faq_q_title_myth1'] = "Mite #1 - Peercoin és només un clon de Bitcoin.";
 $locale_strings['cat']['faq_q_desc_myth1'] = "
 						<p>Peercoin és una de les poques monedes úniques que no són tan sols un clon del codi de Bitcoin.
 				           Peercoin és la primera moneda en introduïr una combinació de proof-of-stake/proof-of-work conjuntament amb d'altres mecanismes energèticamente eficients. De fet, moltes monedes alternatives estan integrant avuí en dia en els seus codis el proof-of-stake de Peercoin.
 				           <br/> <br/>
 						   Font: <a href='http://en.wikipedia.org/wiki/PPCoin#Distinguishing_features'>http://en.wikipedia.org/wiki/PPCoin#Distinguishing_features</a>
 						</p>";
+$locale_strings['zh']['faq_q_desc_myth1'] = "
+						<p>点点币是一个独特而创新的货币绝不简简单单是比特币的一个克隆。点点币是第一个将股权证明应用到加密货币中的。事实上，很多货币都在学习点点币把股权证明代码加到他们的源码中。<br/> <br/>来源: <a href=\"http://en.wikipedia.org/wiki/PPCoin#Distinguishing_features\">http://en.wikipedia.org/wiki/PPCoin#Distinguishing_features</a>
+						</p>";
+
+$locale_strings['en']['faq_q_title_myth2'] = "Myth #2 - Peercoin is a centralized coin because of checkpointing.";
+$locale_strings['fr']['faq_q_title_myth2'] = "Mythe #2 - Peercoin est une monnaie centralisée à cause des points de contrôle.";
+$locale_strings['es']['faq_q_title_myth2'] = "Mito #2 - Peercoin es una moneda centralizada debido a los puntos de control.";
+$locale_strings['gr']['faq_q_title_myth2'] = "Μύθος #2 - Το Peercoin είναι ένα συγκεντρωτικό νόμισμα λόγω του checkpointing.";
 $locale_strings['cat']['faq_q_title_myth2'] = "Mite #2 - Peercoin és una moneda centralitzada degut als punts de control.";
+$locale_strings['zh']['faq_q_title_myth2'] = "流言 #2 - 因为有检查点所以点点币不是分布式货币.";
+
+$locale_strings['en']['faq_q_desc_myth2'] = "
+						<p>Checkpoints are an additional security measure and were introduced to protect the Peercoin network from attacks when it was in its infancy. Sunny King explains:</p>
+						<p>&quot;The risk of 51% denial-of-service attack on block chain is real, especially to a smaller network. In fact I wouldn’t exclude such a possibility to even bitcoin. Of course such an attack on bitcoin would likely not come from an individual due to the resource required. But it’s irresponsible to say that’s not possible. Just imagine what would happen if bitcoin stops processing transactions for a few days.&quot;</p>
+						<p>As Peercoin's network has grown substantially in the past year, checkpoints will be phased out in one of the next versions, probably in PPC 0.5.</p>";
+$locale_strings['fr']['faq_q_desc_myth2'] = "
+						<p>Les points de contrôle sont une mesure de sécurité supplémentaire qui ont été introduits pour protéger le réseau Peercoin des attaques quand il était dans son enfance. Sunny King explique:</p>
+						<p>&quot;Le risque d'une attaque des 51% par déni-de-service sur la chaîne de blocs est réel, surtout pour un petit réseau. En fait je n'exclurait pas une telle possibilité même pour Bitcoin. Bien sûr une telle attaque sur Bitcoin ne viendrait probablement pas d'un unique individu à cause des ressources requises. Mais il est irresponsable de dire que ce n'est pas possible. Imaginez juste ce qui se passerait si Bitcoin arrêtait de traiter les transactions pendant quelques jours.&quot;</p>
+						<p>Puisque le réseau Peercoin a grandi substantiellement dans l'année passée, les points de contrôle seront supprimés dans l'une des versions à venir, probablement dans PPC 0.5.</p>";
+$locale_strings['es']['faq_q_desc_myth2'] = "
+						<p>Los puntos de control centralizados son una medida de seguridad adicional y fueron introducidos para proteger la red Peercoin de ataques mientras la red está en su infancia. Sunny King lo explica:</p>
+						<p>&quot;El riesgo de un ataque de denegación de servicio del 51% en la cadena de bloques es real, especialmente en una red pequeña. De hecho, no excluyo esta posibilidad incluso en la red Bitcoin. Por supuesto tal ataque a Bitcoin no vendría de una persona individual debido a la cantidad de recursos necesarios para llevar a cabo tal ataque. Pero sería irresponsable decir que no es una posibilidad real. Tan sólo hace falta imaginar qué pasaría si la red dejara de procesar transacciones por unos pocos días.&quot;</p>
+						<p>Ya que la red Peercoin ha crecido sustancialmente durante el pasado año, los puntos de control se eliminarán gradualmente en una de las próximas versiones de Peercoin, probablemente la 0.5.</p>";
+$locale_strings['gr']['faq_q_desc_myth2'] = "
+						<p>Τα checkpoints (σημεία ελέγχου) είναι επιπρόσθετα μέτρα ασφαλείας και είχαν εισαχθεί έτσι ώστε να προστατεύουν το δίκτυο του Peercoin από επιθέσεις όταν ακόμα ήταν στη νηπιακή του ηλικία. Ο Sunny King εξηγεί:</p>
+						<p>&quot;Ο κίνδυνος της 51% denial-of-service επίθεσης στην αλυσίδα block είναι αληθινός, ειδικά σε ένα μικρότερο δίκτυο. Στην πραγματικότητα δεν θα απέκλεια μια τέτοια πιθανότητα ούτε ακόμα και στο bitcoin. Φυσικά μία τέτοια επίθεση στο bitcoin πιθανότατα δεν θα ερχόταν από έναν άτομο λόγω των πόρων που χρειάζεται. Αλλά είναι ανεύθυνο να λέγεται ότι είναι απίθανο να συμβεί. Απλά φανταστείτε τι θα συνέβαινε εάν το bitcoin σταματούσε να επεξεργαζόταν συναλλαγές για μερικές μέρες.&quot;</p>
+						<p>Μιας και το δίκτυο του Peercoin έχει μεγαλώσει ουσιαστικά στον περασμένο χρόνο, τα σημεία ελέγχου σταδιακά θα καταργηθούν σε μία από τις επερχόμενες εκδόσεις, πιθανόν στο PPC 0.5.</p>";
 $locale_strings['cat']['faq_q_desc_myth2'] = "
 						<p>Els punts de control centralitzats són una mesura de seguretat adicional i van ser introduïts per protegir la xarxa Peercoin d'atacs mentre la xarxa està a la seva infancia. Sunny King ho explica:</p>
 						<p>&quot;El risc d'un atac de denegació de servei del 51% a la cadena de blocs és real, especialment a una xarxa petita. De fet, no excloeixo aquesta posibilitat fins i tot a la xarxa Bitcoin. Per suposat aquest atac a Bitcoin no vindria d'una persona individual degut a la quantitat de recursos necessaris per dur a terme tal atac. Però seria irresponsable dir que no és una possibilitat real. Tan sols cal imaginar qué pasaria si la xarxa deixara de processar transaccions durant uns pocos dies.&quot;</p>
 						<p>Ja que la xarxa Peercoin ha crescut substancialment durant l'ultim any, els punts de control s'eliminaran gradualment en una de les pròximes versions de Peercoin, probablement la 0.5.</p>";
-$locale_strings['cat']['faq_q_title_myth3'] = "Mite #3 - Peercoin té una naturalesa extremadament inflacionària.";
-$locale_strings['cat']['faq_q_desc_myth3'] = "
-						<p>No. Si Peercoin creix ràpidament, l'encunyament mitjançant Stake es reduirà temporalment mentre els dies de moneda es perden degut al comerç d'aquestes. Això causaria que Peercoin fora deflacionària. La naturalesa de les tases de transacció fixes es va disenyar com a mesura de contrarestar això, reduint el volum del total de transaccions. Els defensors de Peercoin argumenten que això disminuirà la deflació.</p>
-						<p>Ademés, Bitcoin experimenta actualment <a href='http://letstalkbitcoin.com/is-bitcoin-overpaying-for-false-security/'>un ~10%</a> d'inflació anual mentre s'acosta al seu subministrament total de 21 milions de monedes. S'<b>espera</b> que quan s'arribi al subministrament total de monedes les tases de transacció seran suficients per mantenir una xarxa segura.</p>
-						<p>Per mantenir una xarxa segura en el futur, Peercoin proveeix una inflació anual de l'1% (recompensa per proof-of-stake) per asegurar-se que hi haurà una xarxa segura, independientement de les tases de transacció. Com s'ha comentat abans, això tornarà la moneda deflacionaria, igual que Bitcoin pretén ser, durant nivells de transaccions alts.</p>";
-
-$locale_strings['cat']['convinced_you_header'] = "¿<b>Convençut</b>?";
-$locale_strings['cat']['convinced_you_desc'] = "Es l'hora de descarregar el client i probar-ho tu mateix. Si tens algun dubte simplement pregunta al <a href='http://www.peercointalk.org/'>forum</a>, o als enllaços de xarxes socials de més avall.";
-
-$locale_strings['cat']['tutorials'] = "Tutorials";
-$locale_strings['cat']['installing_wallet'] = "Instal·lar moneder";
-$locale_strings['cat']['setting_up_wallet'] = "Configurar moneder";
-$locale_strings['cat']['more_ellipsis'] = "Més...";
-$locale_strings['cat']['links'] = "Enllaços";
-$locale_strings['cat']['tools'] = "Eines";
-$locale_strings['cat']['exchanges'] = "Exchanges";
-$locale_strings['cat']['mining'] = "Minar";
-
-
-
-$locale_strings['zh']['languages'] = "语言: ";
-$locale_strings['zh']['download_wallet'] = "下载钱包";
-$locale_strings['zh']['price'] = "价格";
-$locale_strings['zh']['market_cap'] = "市值";
-$locale_strings['zh']['total_supply'] = "供应量";
-$locale_strings['zh']['big_welcome_header'] = "安全的. 可持续的. <span><strong>点点币</strong> 就在这里.</span>";
-$locale_strings['zh']['ticker_last_updated'] = "最后更新: ";
-$locale_strings['zh']['ticker_last_updated_never'] = "从未";
-
-$locale_strings['zh']['why_peercoin_header_innovation'] = "原创 <b>革新</b>";
-$locale_strings['zh']['why_peercoin_desc_innovation'] = "点点币的原创<a href='/bin/peercoin-paper.pdf'>proof-of-stake/proof-of-work(股权证明/工作量证明)混合</a>系统.就像其它<a href='https://en.wikipedia.org/wiki/Cryptocurrency'>加密货币</a>一样, 货币可以通过挖矿产生, 但是,整个网络是被持币者维护的，而不是计算能力强大的<a href='https://en.bitcoin.it/wiki/Pooled_mining'>矿池</a>.";
-$locale_strings['zh']['why_peercoin_header_security'] = "更强的<b>安全性</b>";
-$locale_strings['zh']['why_peercoin_desc_security'] = "使用股权证明/工作量证明混合算法维护网络，减少了<a href='http://www.pcworld.com/article/2060840/selfish-miner-attack-could-devastate-bitcoin-researchers-say.html'>自私矿工攻击</a>, 和<a href='https://en.bitcoin.it/wiki/Weaknesses'>51%攻击</a>, 而且不易于像其他货币一样被不法之徒危害。";
-$locale_strings['zh']['why_peercoin_header_efficiency'] = "低<b>能耗</b>";
-$locale_strings['zh']['why_peercoin_desc_efficiency'] = "点点币比那些需求大量硬件进行哈希运算的货币要节能环保.股权证明不会出现比特币的<a href='http://letstalkbitcoin.com/is-bitcoin-overpaying-for-false-security/'>十亿美元税金</a>事件";
-$locale_strings['zh']['why_peercoin_button'] = "为什么选择点点币?";
-$locale_strings['zh']['why_peercoin_title'] = "为什么选择<span>点点币</span>?";
-$locale_strings['zh']['why_peercoin_desc'] = "点点币网络通过使用优秀的创新算法，在消耗更少的能源的同时, 提供更好的安全加密。比其他加密货币更能公平的回报用户。";
-
-$locale_strings['zh']['fund_peercoin'] = "支持 <span>点点币.</span>";
-$locale_strings['zh']['fund_peercoin_accepting_donations'] = "我们现在接受捐赠用于点点币的开发和Web基金.";
-$locale_strings['zh']['fund_peercoin_donations_btc'] = "BTC 捐赠: ";
-$locale_strings['zh']['fund_peercoin_donations_ppc'] = "PPC 捐赠: ";
-$locale_strings['zh']['block_explorer'] = "区块浏览";
-
-$locale_strings['zh']['faq_header'] = "常见 <span>问题</span>";
-$locale_strings['zh']['faq_q_title_innovation'] = "说说你们的创新之处.";
-$locale_strings['zh']['faq_q_desc_innovation'] = "
-						<p>点点币引以自豪的创新之处就是股权证明和工作量证明混合系统.</p>
-						<p>就像其他加密货币, 刚开始，货币通过挖矿产生. 但是,随着挖矿难度的提高,持币者将可以随时间推移而获得利息.例如拥有1%货币的人将可以获得1%利息区块的货币.</p>
-						<p>并且，这还带来了更高的安全加密级别。任何的破解都会变得异常艰难.</p>";
-$locale_strings['zh']['faq_q_title_security'] = "说说你们更强的安全性.";
-$locale_strings['zh']['faq_q_desc_security'] = "
-						<p>使用股权证明和工作量证明混合算法产生的区块可以避免自私矿工攻击和\">50%\" 攻击,不易于像其他货币一样被不法之徒危害.</p>
-						<p>股权证明算法作为安全加密的核心。它极大地加大了攻击的难度和代价.获得51%的货币远比51%的矿工难多了. 并且在\">50%\"攻击中黑客会有巨大的风险，因为，他有这种货币的绝大多数，他需要自己承担价值受损的风险</p>
-						<p>点点币同时强制了交易税来防止被不法之徒危害.</p>";
-$locale_strings['zh']['faq_q_title_efficiency'] = "说说你们的低能耗.";
-$locale_strings['zh']['faq_q_desc_efficiency'] = "
-						<p>通过股权证明产生区块耗能少.在长远上，当挖矿效益低时，大部分的区块将会是证明型股权区块，这将是非常环保的.</p>
-				        <p>股权证明还可以防止出现比特币一样的十亿美元税金事件.你可以从<a href='http://letstalkbitcoin.com/is-bitcoin-overpaying-for-false-security/'>这里</a>了解更多信息.</p>";
-$locale_strings['zh']['faq_q_title_myth1'] = "流言 #1 - 点点币只是比特币的一个克隆.";
-$locale_strings['zh']['faq_q_desc_myth1'] = "
-						<p>点点币是一个独特而创新的货币绝不简简单单是比特币的一个克隆。点点币是第一个将股权证明应用到加密货币中的。事实上，很多货币都在学习点点币把股权证明代码加到他们的源码中。<br/> <br/>来源: <a href=\"http://en.wikipedia.org/wiki/PPCoin#Distinguishing_features\">http://en.wikipedia.org/wiki/PPCoin#Distinguishing_features</a>
-						</p>";
-$locale_strings['zh']['faq_q_title_myth2'] = "流言 #2 - 因为有检查点所以点点币不是分布式货币.";
 $locale_strings['zh']['faq_q_desc_myth2'] = "
 						<p>检查点以一个额外的安全措施，旨在初期阶段保护点点币网络。Sunny King解释:</p>
 						<p>&quot;区块链上51%拒绝服务攻击的风险是真实存在的，特别是对于一个小型网络来说。事实上我也不排除比特币也有这种可能性。当然限于资源需求，对比特币进行这种攻击不太可能来源于个人。但不能保证它不会发生。试想一下，如果比特币将停止处理交易数天会发生什么。&quot;</p>
 						<p>鉴于过去几年中点点币网络大幅增长，检查点将会在后续版本中移除，可能会是PPC 0.5.</p>";
+
+$locale_strings['en']['faq_q_title_myth3'] = "Myth #3 - Peercoin is extremely inflationary in nature.";
+$locale_strings['fr']['faq_q_title_myth3'] = "Mythe #3 - Peercoin est extrèmement inflationniste par nature.";
+$locale_strings['es']['faq_q_title_myth3'] = "Mito #3 - Peercoin tiene una naturaleza extremadamente inflacionara.";
+$locale_strings['gr']['faq_q_title_myth3'] = "Μύθος #3 - Το Peercoin είναι εξαιρετικά πληθωριστικό στη φύση.";
+$locale_strings['cat']['faq_q_title_myth3'] = "Mite #3 - Peercoin té una naturalesa extremadament inflacionària.";
 $locale_strings['zh']['faq_q_title_myth3'] = "流言 #3 - 点点币在本质上是高通胀.";
+
+$locale_strings['en']['faq_q_desc_myth3'] = "
+						<p>Nope. If Peercoin grows rapidly, stake minting may temporarily decrease as coin days are lost when trading. This would cause Peercoin to become deflationary. The flat nature of the transaction fees is intended to counter this by decreasing total transaction volume. Proponents of Peercoin argue that this will decrease deflation.</p>
+						<p>Furthermore, Bitcoin currently experiences <a href='http://letstalkbitcoin.com/is-bitcoin-overpaying-for-false-security/'>a ~10%</a> inflation per year as it approaches its total supply of 21 million. It is <b>hoped</b> that when the total supply is reached that the transactions fees will be enough to sustain a secure network.</p>
+						<p>To maintain a secure network in the future, Peercoin has a 1% a year inflation (proof-of-stake reward) to make sure there will be a secure network, no matter the transaction fees. As stated before this may become deflationary, as Bitcoin aims to be, during high volumes of transactions.</p>";
+$locale_strings['fr']['faq_q_desc_myth3'] = "
+						<p>Non. Si Peercoin grandit rapidement, la génération de monnaie par preuve-de-part peut diminuer temporairement car des jours-pièces sont perdus dans les échanges. Ceci rendrait Peercoin déflationniste. Les frais de transaction fixes sont prévus pour contrer ceci en reduisant le volume total de transactions. Les promoteurs de Peercoin considèrent que cela réduira la déflation.</p>
+						<p>De plus, Bitcoin connaît actuellement une inflation <a href='http://letstalkbitcoin.com/is-bitcoin-overpaying-for-false-security/'>d'environ 10%</a> par an alors qu'il approche de sa masse monétaire totale de 21 millions. Les gens <b>espèrent</b> que lorsque la masse monétaire maximale sera atteinte, les frais de transaction seront suffisants pour maintenir la sécurité du réseau.</p>
+						<p>Pour maintenir la sécurité du réseau dans le futur, Peercoin a une inflation annuelle de 1% (récompense de preuve-de-part) afin de s'assurer un réseau sûr, quels que soient les frais de transaction. Comme indiqué précedemment ceci pourrait rendre Peercoin déflationniste, comme Bitcoin vise à l'être, pendant les hauts volumes de transactions.</p>";
+$locale_strings['es']['faq_q_desc_myth3'] = "
+						<p>No. Si Peercoin crece rápidamente, el acuñado mediante Stake se reducirá temporalmente mientras los días de moneda se pierden debido al comercio de éstas. Esto causaría que Peercoin fuera deflacionarioy. La naturaleza de las tasas de transacción fijadas se diseñaron como medida de contrarestar esto, reduciendo el volumen de total de transacciones. Los defensores de Peercoin argumentan que esto disminuirá la deflación.</p>
+						<p>Además, Bitcoin experimenta actualmente <a href='http://letstalkbitcoin.com/is-bitcoin-overpaying-for-false-security/'>un ~10%</a> de inflación anual mientras de acerca a su suministro total de 21 millones de monedas. Se <b>espera</b> que cuando se alcance el suministro total de monedas las tasas de transacción serán suficientes para mantener una red segura.</p>
+						<p>Para mantener una red segura en el futuro, Peercoin provee una inflación anual del 1% (recompensa por proof-of-stake) para asegurarse que habrá una red segura, independientemente de las tasas de transacción. Como se ha comentado antes, esto volverá la moneda deflacionaria, igual que Bitcoin pretende ser, durante niveles de transacciones altos.</p>";
+$locale_strings['gr']['faq_q_desc_myth3'] = "
+						<p>Όχι. Εάν το Peercoin μεγαλώνει γρήγορα, η χρηματοδότηση της κοπής ίσως μειωθεί προσωρινά όσο μέρες νομίσματος θα χάνονται καθώς γίνονται διακινήσεις. Αυτό θα έκανε το Peercoin να γίνει αποπληθωριστικό. Η επίπεδη φύση των τελών συναλλαγής σκοπεύει να το αντιμετωπίσει αυτό με το να μειώσει το συνολικό όγκο συναλλαγών. Οι υποστηρικτές του Peercoin υποστηρίζουν ότι αυτό θα μειώσει τον αποπληθωρισμό.</p>
+						<p>Επιπροσθέτως, το Bitcoin αυτή τη στιγμή βιώνει <a href='http://letstalkbitcoin.com/is-bitcoin-overpaying-for-false-security/'>ένα ~10%</a> πληθωρισμό το χρόνο όσο πλησιάζει τη συνολική προσφορά των 21 εκατομμυρίων. <b>Ελπίζεται</b> ότι όταν φτάσει αυτό το ποσό τα κόστα συναλλαγής θα είναι αρκετά για την διατήρηση ενός ασφαλούς δικτύου.</p>
+						<p>Για τη διατήρηση ενός ασφαλούς δικτύου στο μέλλον, το Peercoin έχει 1% πληθωρισμό το χρόνο (ανταμοιβή της απόδειξης-της-συμμετοχής) για να διασφαλήσει ότι θα υπάρχει ένα ασφαλές δίκτυο, χωρίς να δίνει καμία σημασία στα τέλη συναλλαγών. Όπως προαναφέρθηκε αυτό μπορεί να γίνει αποπληθωριστικό, όπως στοχεύει και το Bitcoin να γίνει, κατά τη διάρκεια μεγάλου όγκου συναλλαγών.</p>";
+$locale_strings['cat']['faq_q_desc_myth3'] = "
+						<p>No. Si Peercoin creix ràpidament, l'encunyament mitjançant Stake es reduirà temporalment mentre els dies de moneda es perden degut al comerç d'aquestes. Això causaria que Peercoin fora deflacionària. La naturalesa de les tases de transacció fixes es va disenyar com a mesura de contrarestar això, reduint el volum del total de transaccions. Els defensors de Peercoin argumenten que això disminuirà la deflació.</p>
+						<p>Ademés, Bitcoin experimenta actualment <a href='http://letstalkbitcoin.com/is-bitcoin-overpaying-for-false-security/'>un ~10%</a> d'inflació anual mentre s'acosta al seu subministrament total de 21 milions de monedes. S'<b>espera</b> que quan s'arribi al subministrament total de monedes les tases de transacció seran suficients per mantenir una xarxa segura.</p>
+						<p>Per mantenir una xarxa segura en el futur, Peercoin proveeix una inflació anual de l'1% (recompensa per proof-of-stake) per asegurar-se que hi haurà una xarxa segura, independientement de les tases de transacció. Com s'ha comentat abans, això tornarà la moneda deflacionaria, igual que Bitcoin pretén ser, durant nivells de transaccions alts.</p>";
 $locale_strings['zh']['faq_q_desc_myth3'] = "
 						<p>不是这样的. 如果点点币发展迅速, 在交易过程中币的币龄就会很低, 就不会产生利息也就没有通胀率高的问题。 同时交易税会控制交易量防止紧缩。</p>
 						<p>另外, Bitcoin面临着<a href='http://letstalkbitcoin.com/is-bitcoin-overpaying-for-false-security/'>~10%</a>通胀每年，当它达到2100万总量时.当达到供应总量后才有足够的交易费用以维护一个安全的网络。</p>
 						<p>为了将来维护一个安全的网络，点点币有每年1%的通胀(股权证明的利息), 而不管交易费有多少。如前所述，在此之前可能会是通货紧缩，比特币的目标是支持高交易量。</p>";
 
+$locale_strings['en']['convinced_you_header'] = "Convinced <b>you</b>?";
+$locale_strings['fr']['convinced_you_header'] = "<b>Convaincu</b>?";
+$locale_strings['es']['convinced_you_header'] = "¿<b>Convencido</b>?";
+$locale_strings['gr']['convinced_you_header'] = "<b>Σε</b> πείσαμε;";
+$locale_strings['cat']['convinced_you_header'] = "¿<b>Convençut</b>?";
 $locale_strings['zh']['convinced_you_header'] = "已使<b>你</b>信服?";
+
+$locale_strings['en']['convinced_you_desc'] = "Time to download the client, and try it yourself. If you have any questions just ask on the <a href='http://www.peercointalk.org/'>forum</a>, or the social links below.";
+$locale_strings['fr']['convinced_you_desc'] = "Il est temps de télécharger le client, et de l'essayer par vous-même. Si vous avez des questions, posez les sur le <a href='http://www.peercointalk.org/'>forum</a>, ou sur les réseaux sociaux ci-dessous.";
+$locale_strings['es']['convinced_you_desc'] = "Es hora de descargar el cliente y probarlo tú mismo. Si tienes alguna duda simplemente pregunta en el <a href='http://www.peercointalk.org/'>foro</a>, o los enlaces a redes sociales de más abajo.";
+$locale_strings['gr']['convinced_you_desc'] = "Ώρα να κατεβάσεις το πρόγραμμα, και να το δοκιμάσεις ο ίδιος. Εάν έχεις οποιαδήποτε ερώτηση απλά ρώτα στο <a href='http://www.peercointalk.org/'>φόρουμ</a>, ή στους σύνδεσμους κοινωνικών δίκτυων από κάτω.";
+$locale_strings['cat']['convinced_you_desc'] = "Es l'hora de descarregar el client i probar-ho tu mateix. Si tens algun dubte simplement pregunta al <a href='http://www.peercointalk.org/'>forum</a>, o als enllaços de xarxes socials de més avall.";
 $locale_strings['zh']['convinced_you_desc'] = "是时候下载钱包客户端，自己尝试一下了。有任何问题可以到<a href='http://www.peercointalk.org/'>论坛</a>交流, 或下面社交媒体获取信息。";
 
+$locale_strings['en']['tutorials'] = "Tutorials";
+$locale_strings['fr']['tutorials'] = "Tutoriels";
+$locale_strings['es']['tutorials'] = "Tutoriales";
+$locale_strings['gr']['tutorials'] = "Οδηγοί";
+$locale_strings['cat']['tutorials'] = "Tutorials";
 $locale_strings['zh']['tutorials'] = "新手指导";
+
+$locale_strings['en']['installing_wallet'] = "Installing a Wallet";
+$locale_strings['fr']['installing_wallet'] = "Installer le Portefeuille";
+$locale_strings['es']['installing_wallet'] = "Instalar monedero";
+$locale_strings['gr']['installing_wallet'] = "Εγκατάσταση Πορτοφολιού";
+$locale_strings['cat']['installing_wallet'] = "Instal·lar moneder";
 $locale_strings['zh']['installing_wallet'] = "安装钱包";
+
+$locale_strings['en']['setting_up_wallet'] = "Setting Up Wallet";
+$locale_strings['fr']['setting_up_wallet'] = "Configurer le Portefeuille";
+$locale_strings['es']['setting_up_wallet'] = "Configurar monedero";
+$locale_strings['gr']['setting_up_wallet'] = "Ρύθμιση Πορτοφολιού";
+$locale_strings['cat']['setting_up_wallet'] = "Configurar moneder";
 $locale_strings['zh']['setting_up_wallet'] = "设置钱包";
+
+$locale_strings['en']['more_ellipsis'] = "More...";
+$locale_strings['fr']['more_ellipsis'] = "Plus...";
+$locale_strings['es']['more_ellipsis'] = "Más...";
+$locale_strings['gr']['more_ellipsis'] = "Περισσότερα...";
+$locale_strings['cat']['more_ellipsis'] = "Més...";
 $locale_strings['zh']['more_ellipsis'] = "更多...";
+
+//footer
+
+$locale_strings['en']['links'] = "Links";
+$locale_strings['fr']['links'] = "Liens";
+$locale_strings['es']['links'] = "Enlaces";
+$locale_strings['gr']['links'] = "Σύνδεσμοι";
+$locale_strings['cat']['links'] = "Enllaços";
 $locale_strings['zh']['links'] = "链接";
+
+$locale_strings['en']['tools'] = "Tools";
+$locale_strings['fr']['tools'] = "Outils";
+$locale_strings['es']['tools'] = "Herramientas";
+$locale_strings['gr']['tools'] = "Εργαλεία";
+$locale_strings['cat']['tools'] = "Eines";
 $locale_strings['zh']['tools'] = "工具";
+
+$locale_strings['en']['exchanges'] = "Exchanges";
+$locale_strings['fr']['exchanges'] = "Échanges";
+$locale_strings['es']['exchanges'] = "Exchanges";
+$locale_strings['gr']['exchanges'] = "Ανταλλαγές";
+$locale_strings['cat']['exchanges'] = "Exchanges";
 $locale_strings['zh']['exchanges'] = "交易";
+
+$locale_strings['en']['mining'] = "Mining";
+$locale_strings['fr']['mining'] = "Extraction";
+$locale_strings['es']['mining'] = "Minado";
+$locale_strings['gr']['mining'] = "Εξόρυξη";
+$locale_strings['cat']['mining'] = "Minar";
 $locale_strings['zh']['mining'] = "挖矿";
+
+$locale_strings['en']['languages'] = "Languages: ";
+$locale_strings['fr']['languages'] = "Langues: ";
+$locale_strings['es']['languages'] = "Idiomas: ";
+$locale_strings['gr']['languages'] = "Γλώσσες: ";
+$locale_strings['cat']['languages'] = "Idiomes: ";
+$locale_strings['zh']['languages'] = "语言: ";
+
+//javascript
+
+$locale_strings['en']['second_ago'] = "second ago";
+$locale_strings['fr']['second_ago'] = "second ago";
+$locale_strings['es']['second_ago'] = "second ago";
+$locale_strings['gr']['second_ago'] = "δευτερόλεπτο πριν";
+$locale_strings['cat']['second_ago'] = "second ago";
+$locale_strings['zh']['second_ago'] = "second ago";
+
+$locale_strings['en']['seconds_ago'] = "seconds ago";
+$locale_strings['fr']['seconds_ago'] = "seconds ago";
+$locale_strings['es']['seconds_ago'] = "seconds ago";
+$locale_strings['gr']['seconds_ago'] = "δευτερόλεπτα πριν";
+$locale_strings['cat']['seconds_ago'] = "seconds ago";
+$locale_strings['zh']['seconds_ago'] = "seconds ago";


### PR DESCRIPTION
Commit 1.
Header (dropdown menu as well as the title of the main page) are now translatable.

Greek translation has been added to that section.

Also, I organized locale/strings.php in a better way. Now strings that are missing translations are found much more easily and completely new translations are added more easily.

Commit 2.
Also, made 'seconds changed' (from ticker.js) translatable and added the Greek translation for it.
