### PR TITLE
Redirect whitepaper/download links; fix grammar/word usage

### DIFF
--- a/minting.php
+++ b/minting.php
@@ -9,7 +9,7 @@
 				<div class="col-lg-12">
 					<p>
 						<strong>Introduction</strong><br />
-						Peercoin (PPC) uses a novel, green and very interesting method of network validation and mining. Most alternative crypto-currencies in existence are forks of Bitcoin, with changed mining parameters or different mining algorithms. Miners maintain the network and check transactions, while spending a lot of energy on cryptographic brute force puzzles. <a href="https://blockchain.info/stats">Blockchain.info</a> estimates that mid December 2013, Bitcoin mining takes up 22 million dollars or 150.000 megawatts of energy <em>per day</em>. Peercoin also started out as a Proof-Of-Work network. But as more blocks and coins have been mined, the network switches slowly to Proof-Of-Stake validation. With it we also switch to a new approach of securing the network. In Peercoin terms this process of generating coins by stake is called minting. And if you have a stake in Peercoin (PPC) coins, you can mint too!
+						Peercoin (PPC) uses a novel, green, and very interesting method of network validation and mining. Most alternative cryptocurrencies in existence are forks of Bitcoin with changed mining parameters or different mining algorithms. Miners maintain the network and check transactions, while spending a lot of energy on cryptographic brute force puzzles. <a href="https://blockchain.info/stats">Blockchain.info</a> estimates that mid December 2013, Bitcoin mining takes up 22 million dollars or 150.000 megawatts of energy <em>per day</em>. Peercoin also started out as a Proof-Of-Work network. But as more blocks and coins have been mined, the network switches slowly to Proof-Of-Stake validation. With it we also switch to a new approach of securing the network. In Peercoin terms this process of generating coins by stake is called minting. And if you have a stake in Peercoin (PPC) coins, you can mint too!
 					</p>
 					<p>
 						Proof-of-work and proof-of-stake are methods of securing cryptocurrency networks. Bitcoin uses a purely proof-of-work-based system, in which the probability of solving a block (and getting the block reward) depends on hashrate. On the Bitcoin network, rewards are distributed solely according to work done by miners.
@@ -47,7 +47,7 @@
 				<div class="col-lg-12">
 					<p>
 						<strong>What is minting, exactly?</strong><br />
-						All coins in the Peercoin network collect coin age. Your stake is calculated from this coinage, measured by last transaction, and multiplied with the amount of coin (time * coins). Transferred coins lose their age and start a new "life" as fresh coins. When you keep coins for 30 days, they are old enough to start the minting process. From that moment on the software tests the 'search space' given by the coinage, the limited options are tested if they "solve the puzzle" like in Bitcoin mining. You can simply think of this by comparing it with a raffle. But it is a raffle that lets you keep the tickets every time you do not win a round. And with it the chance of producing a valid solution of the next puzzle increases. More coins equal more raffle tickets. So 100 coins at an age of 30 days are twice as likely to solve the "puzzle" as 50 coins with 30 age days. The maximum age a coin can have is 90 days, after this the coin does not age further. When a puzzle is solved you can mint 1% of your input, by sending 101% of the coin to yourself. With it you "consume" your build up coin-age. As you test against a limited number of raffle tickets, the 'limited search space', this requires significantly less power. Attacks become more difficult as well, instead of controlling 51% calculating power to take over the block chain, you need 51% of the coins that are put up as stake! When a block is minted, your new coins will be unspendable for a period of 520 blocks (~ 3.6 days with 10 minutes blocks). More information can be found in the Peercoin <a href="bin/peercoin-paper.pdf">whitepaper</a>.
+						All coins in the Peercoin network collect coin age. Your stake is calculated from this coin age, measured by last transaction, and multiplied with the amount of coins (time * coins). Transferred coins lose their age and start a new "life" as fresh coins. When you keep coins for 30 days, they are old enough to start the minting process. From that moment on the software tests the "search space" given by the coin age, the limited options are tested if they "solve the puzzle" like in Bitcoin mining. You can simply think of this by comparing it with a raffle. But it is a raffle that lets you keep the tickets every time you do not win a round. And with it the chance of producing a valid solution of the next puzzle increases. More coins equal more raffle tickets. So 100 coins at an age of 30 days are twice as likely to solve the "puzzle" as 50 coins with 30 age days. The maximum age a coin can have is 90 days, after this the coin does not age further. When a puzzle is solved you can mint 1% of your input, by sending 101% of the coin to yourself. With it you "consume" your built-up coin age. As you test against a limited number of raffle tickets (the "limited search space"), this requires significantly less power. Attacks become more difficult as well, instead of controlling 51% calculating power to take over the block chain, you need 51% of the coins that are put up as stake! When a block is minted, your new coins will be unspendable for a period of 520 blocks (~ 3.6 days with 10 minutes blocks). More information can be found in the Peercoin <a href="/whitepaper">whitepaper</a>.
 					</p>
 				</div>
 			</div>
@@ -56,9 +56,9 @@
 				<div class="col-lg-12">
 					<p>
 						<strong>Minting Return</strong><br />
-						Statistically you will get 1% interest on average on your coins per year if you mint. You only mint when your wallet is open, but as the resources use is a lot lower this will not lock up the computer or waste much power. Your wallet is unlocked, but you will still need your passphrase for transactions. An alternative strategy would be to wait till you have a lot of coinage and have a larger chance of minting a block. This would be around 90 days after transaction. However your return will be a little less compared with constant minting. Future wallet version will support in wallet minting, possibly without decrypting.
+						Statistically you will get 1% interest on average on your coins per year if you mint. You only mint when your wallet is open, but as the resources use is a lot lower this will not lock up the computer or waste much power. Your wallet is unlocked, but you will still need your passphrase for transactions. An alternative strategy would be to wait until you have a lot of coin age and have a larger chance of minting a block. This would be around 90 days after transaction. However your return will be a little less compared with constant minting. Future wallet version will support in-wallet minting, possibly without decrypting.
 					</p>
-					<p>The Peercoin-QT wallet software takes care of this whole process automatically but it needs some configuration before it can start.</p>
+					<p>The Peercoin-QT wallet software takes care of this whole process automatically, but it needs some configuration before it can start.</p>
 				</div>
 			</div>
 
@@ -77,9 +77,9 @@
 						<div class="item">
 							<div class="col-lg-12">
 								<h4>Set-up required software:</h4>
-								<p>	Download and install the <a href="http://sourceforge.net/projects/ppcoin/files/">Peercoin-Qt wallet</a> if you have not done so already.
-								Encrypt your wallet with a good passphrase. Write this down and keep it somewhere safe, if you forget the passphrase you will lose your coins.
-								The wallet encryption option can be found under the settings tab in the PeercoinQt wallet program. </p>
+								<p>	Download and install the <a href="/downloads">Peercoin-Qt wallet</a> if you have not done so already.
+								Encrypt your wallet with a good passphrase. Write this down and keep it somewhere safe; if you forget the passphrase you will lose your coins.
+								The wallet encryption option can be found under the settings tab in the Peercoin-Qt wallet program. </p>
 								<h4>Configure the software: </h4>
 								<p>Open up explorer and select the navigation bar. Type in: %appdata%/PPCoin</p>
 								<img src="assets/img/minting1.png" alt="Minting" />
@@ -129,7 +129,7 @@
 							<div class="col-lg-12">
 								<p>Save the document and rename it to Minting.bat<br />
 								<h4>Start minting:</h4>
-								Run the PeercoinQt wallet. The bottom left should display a message that the wallet is locked and the minting process is suspended.</p>
+								Run the Peercoin-Qt wallet. The bottom left should display a message that the wallet is locked and the minting process is suspended.</p>
 								<img src="assets/img/minting3.png" alt="Minting" />
 								<p>Now double click the minting.bat file and enter your passphrase.<br /></p>
 								<img src="assets/img/minting4.png" alt="Minting" /><br />
@@ -145,7 +145,7 @@
 					<div id="collapseTwo" class="panel-collapse collapse">
 						<div class="item">
 							<div class="col-lg-12">
-								<p> For this tutorial we'll assume the binaries are installed. If you have you can skip the next few lines. Otherwise use the binaries provided on the sourceforge page, click to download them: <a href="http://sourceforge.net/projects/ppcoin/files/0.3.0/ppcoin-0.3.0-linux.tar.gz/download">here</a>.
+								<p> For this tutorial we'll assume the binaries are installed. If you have you can skip the next few lines. Otherwise use the binaries provided on the <a href="/downloads">downloads</a> page.
 								<br> Download the compressed binaries either by command line or via the browser. Decompress the binaries and copy over the contents of either the 32bit or 64bit folder (depending on your CPU) to the usr/bin directory or whichever directory you prefer for your binaries.
 								We'll use the QT version of Peercoin: ppcoin-qt. Navigate to the /usr/bin folder and execute the ppcoin-qt binary. This will set-up the required folders. Encrypt the wallet and write down the passphrase. Don't lose it!
 								Now close the Peercoin-QT client.</p>
@@ -173,8 +173,8 @@
 	ppcoind walletpassphrase &lt;secretpasswordtoyourwallet&gt; 9999999 true
 </pre>
 
-								<p>This unlocks the wallet for minting and starts the minting process if you have the Peercoin-Qt client open. After a few second you should see the padlock on the bottom right unlock. Congratulations you are minting!
-										Don't forget to back-up your private key by backing-up the wallet.dat from the ~/.ppcoin folder or extracting the private key.
+								<p>This unlocks the wallet for minting and starts the minting process if you have the Peercoin-Qt client open. After a few second you should see the padlock on the bottom right unlock. Congratulations--you are minting!
+										Don't forget to back-up your private key by backing-up the wallet.dat file from the ~/.ppcoin folder or extracting the private key.
 								</p>
 							</div>
 						</div>

--- a/page_content/resources/tab_res_mine.php
+++ b/page_content/resources/tab_res_mine.php
@@ -1,7 +1,7 @@
 <h2>Mining Pools</h2>
               <p>
-            Peercoin is a Proof-Of-Work/Proof of Stake hybrid coin that is compatible with the same ASIC hardware used on  the bitcoin network. Initially the ratio of newly produced coins favored mined coins over minted coinds.  However over time as more coin are generated, the ratio of newly produced coins shifts to favor ones produced via Proof-Of-Stake minting. With this, the increasing popularity of Peercoin, increased minting rate, and the decreasing return on mining, competition for blocks becomes fiercer.
-            Even with powerful hardware it is difficult to mine alone.	Mining pools combine the power of all participants to find block, and share the reward based on shares. Read the instructions of each pool carefully as connection protocols and software
+            Peercoin is a Proof-Of-Work/Proof of Stake hybrid coin that is compatible with the same ASIC hardware used on  the bitcoin network. Initially the ratio of newly produced coins favored mined coins over minted coinds.  However over time as more coins are generated, the ratio of newly produced coins shifts to favor ones produced via Proof-Of-Stake minting. With this, the increasing popularity of Peercoin, increasing minting rate, and the decreasing return on mining, competition for blocks becomes fiercer.
+            Even with powerful hardware it is difficult to mine alone.	Mining pools combine the power of all participants to find blocks and share the reward based on shares. Read the instructions of each pool carefully as connection protocols and software
             use can change between pools.
           </p>
 

--- a/participate.php
+++ b/participate.php
@@ -6,7 +6,7 @@
 	        <div class="item">
 	        	<h2 class="maintitle">Improve Peercoin.net</h2>
 	        	<p>
-	        		You could help improve this website by translating it to other languages, adding content, and help maintain it. 
+	        		You could help improve this website by translating it to other languages, adding content, and helping maintain it.
 	        		You get paid automatically in Bitcoin and Peercoin for committing source code. The open source repository is <a href="https://github.com/super3/peercoin.net">here</a>. 
 	        		The website is automatically updated from the repository every 10 minutes. We are currently paying the following balances per commit: <br/>
 	        		<img src="http://tip4commit.com/projects/222.svg" alt="tip4commit"/>


### PR DESCRIPTION
Link to /whitepaper and /downloads instead of directly linking to
binaries.  This change also includes various grammatical fixes and word
substitutions (for example, "coin age" rather than "coinage" to
correspond with the language used in the whitepaper).
